### PR TITLE
Bug fixes & updates

### DIFF
--- a/docs/explanation/training_phases.md
+++ b/docs/explanation/training_phases.md
@@ -88,11 +88,11 @@ Phase Start
 │  ├─ on_epoch_start callbacks
 │  ├─ Batch 0
 │  │  ├─ on_batch_start callbacks
-│  │  ├─ yield ExecutionContext → ModelGraph.train_step()
+│  │  ├─ yield ExecutionContext -> ModelGraph.train_step()
 │  │  └─ on_batch_end callbacks (accumulate loss)
 │  ├─ Batch 1
 │  │  ├─ on_batch_start callbacks
-│  │  ├─ yield ExecutionContext → ModelGraph.train_step()
+│  │  ├─ yield ExecutionContext -> ModelGraph.train_step()
 │  │  └─ on_batch_end callbacks (accumulate loss)
 │  ├─ ...
 │  └─ on_epoch_end callbacks

--- a/docs/how_to/05_create_experiment.ipynb
+++ b/docs/how_to/05_create_experiment.ipynb
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "id": "1",
    "metadata": {},
    "outputs": [],
@@ -113,10 +113,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "id": "5",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Experiment: my_experiment\n",
+      "Context:    <modularml.core.experiment.experiment_context.ExperimentContext object at 0x733a23bfdf70>\n"
+     ]
+    }
+   ],
    "source": [
     "exp = Experiment(label=\"my_experiment\", registration_policy=\"overwrite\")\n",
     "print(f\"Experiment: {exp.label}\")\n",
@@ -191,10 +200,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "id": "11",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FeatureSet(label='SensorData', n_samples=500)\n",
+      "Splits: ['train', 'test']\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "```{mermaid}\n",
+       "flowchart LR\n",
+       "\tn0 e0@-->|\"n=400\"| n1\n",
+       "\tn0 e1@-->|\"n=100\"| n2\n",
+       "\n",
+       "\tn0@{ label: \"<b>FeatureSet</b><br>'SensorData'<br>n=500<br>──────────<br><b>features</b><br>  voltage.raw: (10,)<br><b>targets</b><br>  soh.raw: ()\", shape: rect }\n",
+       "\tn1@{ label: \"<b>Split</b><br>'train'<br>n=400<br>──────────<br><b>features</b><br>  voltage.raw: (10,)<br><b>targets</b><br>  soh.raw: ()<br>──────────<br><b>overlap</b><br>  test: 0\", shape: rect }\n",
+       "\tn2@{ label: \"<b>Split</b><br>'test'<br>n=100<br>──────────<br><b>features</b><br>  voltage.raw: (10,)<br><b>targets</b><br>  soh.raw: ()<br>──────────<br><b>overlap</b><br>  train: 0\", shape: rect }\n",
+       "\tn0:::FeatureSet\n",
+       "\tn1:::FeatureSetView\n",
+       "\tn2:::FeatureSetView\n",
+       "\tclassDef FeatureSet stroke-width: 2px, stroke-dasharray: 0, stroke: #AA00FF, fill: #E1BEE7, color:#000000;\n",
+       "\tclassDef FeatureSetView stroke-width: 2px, stroke-dasharray: 0, stroke: #AA00FF, fill: #F3E5F5, color:#000000;\n",
+       "\n",
+       "\tclassDef NoAnimation stroke-dasharray: 0;\n",
+       "\tclass e0 NoAnimation\n",
+       "\tclass e1 NoAnimation\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Create synthetic data\n",
     "rng = np.random.default_rng(42)\n",
@@ -224,10 +271,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "id": "12",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "```{mermaid}\n",
+       "flowchart LR\n",
+       "\tn1 e0@-->|\"(1, 10)\"| n0\n",
+       "\tn0 e1@-->|\"(1, 1)\"| n2\n",
+       "\n",
+       "\tn0@{ label: \"<b>ModelNode</b><br>'MLP'  &lt;torch&gt;\", shape: rect }\n",
+       "\tn1@{ label: \"<b>FeatureSet</b><br>'SensorData'<br>n=500\", shape: rect }\n",
+       "\tn2@{ label: \" \", shape: circle }\n",
+       "\tn0:::ModelNode\n",
+       "\tn1:::FeatureSet\n",
+       "\tn2:::OutputTerminal\n",
+       "\tclassDef ModelNode stroke-width: 2px, stroke-dasharray: 0, stroke: #2962FF, fill: #BBDEFB, color:#000000;\n",
+       "\tclassDef OutputTerminal stroke-width: 2px, stroke-dasharray: 0, stroke: #424242, fill: #616161, color:#FFFFFF;\n",
+       "\tclassDef FeatureSet stroke-width: 2px, stroke-dasharray: 0, stroke: #AA00FF, fill: #E1BEE7, color:#000000;\n",
+       "\n",
+       "\tclassDef NoAnimation stroke-dasharray: 0;\n",
+       "\tclass e0 NoAnimation\n",
+       "\tclass e1 NoAnimation\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "from modularml.models.torch import SequentialMLP\n",
     "\n",
@@ -314,10 +392,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "id": "17",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Train binding node: d1c8f2c2...\n",
+      "Train binding split: train\n"
+     ]
+    }
+   ],
    "source": [
     "# Training binding: requires a sampler\n",
     "train_binding = InputBinding.for_training(\n",
@@ -332,10 +419,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "id": "18",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Eval binding split: test\n"
+     ]
+    }
+   ],
    "source": [
     "# Evaluation binding: no sampler needed\n",
     "eval_binding = InputBinding.for_evaluation(\n",
@@ -373,10 +468,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "id": "20",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loss: mse\n",
+      "Applied on: d1c8f2c2...\n"
+     ]
+    }
+   ],
    "source": [
     "mse_loss = AppliedLoss(\n",
     "    loss=Loss(\"mse\", backend=\"torch\"),\n",
@@ -404,10 +508,61 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "id": "22",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TrainPhase: train\n",
+      "  n_epochs: 3\n",
+      "  losses:   ['mse']\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "```{mermaid}\n",
+       "flowchart LR\n",
+       "\tn0 e1@-->|\"(1, 1)\"| n2\n",
+       "\tn1 e2@-->|\"split: train\"| n3\n",
+       "\tn3 e3@-->|\"(1, 10)\"| n0\n",
+       "\tn4 e4@-.-> n0\n",
+       "\n",
+       "\tn0@{ label: \"<b>ModelNode</b><br>'MLP'  &lt;torch&gt;<br>──────────<br><b>features</b><br>  voltage<br><b>targets</b><br>  soh\", shape: rect }\n",
+       "\tn1@{ label: \"<b>FeatureSet</b><br>'SensorData'<br>n=500\", shape: rect }\n",
+       "\tn2@{ label: \" \", shape: circle }\n",
+       "\tn3@{ label: \"<b>Sampler</b><br>SimpleSampler<br>batch_size: 32<br>split: train\", shape: rect }\n",
+       "\tn4@{ label: \"<b>AppliedLoss</b><br>'mse'<br>loss: mse\", shape: stadium }\n",
+       "\tn0:::ModelNode\n",
+       "\tn1:::FeatureSet\n",
+       "\tn2:::OutputTerminal\n",
+       "\tn3:::FeatureSampler\n",
+       "\tn4:::AppliedLoss\n",
+       "\tclassDef FeatureSet stroke-width: 2px, stroke-dasharray: 0, stroke: #AA00FF, fill: #E1BEE7, color:#000000;\n",
+       "\tclassDef FeatureSampler stroke-width: 2px, stroke-dasharray: 0, stroke: #FF6D00, fill: #FFE0B2, color:#000000;\n",
+       "\tclassDef OutputTerminal stroke-width: 2px, stroke-dasharray: 0, stroke: #424242, fill: #616161, color:#FFFFFF;\n",
+       "\tclassDef ModelNode stroke-width: 2px, stroke-dasharray: 0, stroke: #2962FF, fill: #BBDEFB, color:#000000;\n",
+       "\tclassDef AppliedLoss stroke-width: 2px, stroke-dasharray: 0, stroke: #D50000, fill: #FFCDD2, color:#000000;\n",
+       "\n",
+       "\tclassDef DashMediumAnimation stroke-dasharray: 9,5, stroke-dashoffset: 100, animation: dash 3s linear infinite;\n",
+       "\tclassDef NoAnimation stroke-dasharray: 0;\n",
+       "\tclass e1 NoAnimation\n",
+       "\tclass e2 DashMediumAnimation\n",
+       "\tclass e3 DashMediumAnimation\n",
+       "\tclass e4 NoAnimation\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Option A: Using explicit InputBindings\n",
     "train_phase = TrainPhase(\n",
@@ -425,10 +580,59 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "id": "23",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TrainPhase (from_split): train_from_split\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "```{mermaid}\n",
+       "flowchart LR\n",
+       "\tn0 e1@-->|\"(1, 1)\"| n2\n",
+       "\tn1 e2@-->|\"split: train\"| n3\n",
+       "\tn3 e3@-->|\"(1, 10)\"| n0\n",
+       "\tn4 e4@-.-> n0\n",
+       "\n",
+       "\tn0@{ label: \"<b>ModelNode</b><br>'MLP'  &lt;torch&gt;<br>──────────<br><b>features</b><br>  voltage<br><b>targets</b><br>  soh\", shape: rect }\n",
+       "\tn1@{ label: \"<b>FeatureSet</b><br>'SensorData'<br>n=500\", shape: rect }\n",
+       "\tn2@{ label: \" \", shape: circle }\n",
+       "\tn3@{ label: \"<b>Sampler</b><br>SimpleSampler<br>batch_size: 32<br>split: train\", shape: rect }\n",
+       "\tn4@{ label: \"<b>AppliedLoss</b><br>'mse'<br>loss: mse\", shape: stadium }\n",
+       "\tn0:::ModelNode\n",
+       "\tn1:::FeatureSet\n",
+       "\tn2:::OutputTerminal\n",
+       "\tn3:::FeatureSampler\n",
+       "\tn4:::AppliedLoss\n",
+       "\tclassDef FeatureSet stroke-width: 2px, stroke-dasharray: 0, stroke: #AA00FF, fill: #E1BEE7, color:#000000;\n",
+       "\tclassDef FeatureSampler stroke-width: 2px, stroke-dasharray: 0, stroke: #FF6D00, fill: #FFE0B2, color:#000000;\n",
+       "\tclassDef OutputTerminal stroke-width: 2px, stroke-dasharray: 0, stroke: #424242, fill: #616161, color:#FFFFFF;\n",
+       "\tclassDef ModelNode stroke-width: 2px, stroke-dasharray: 0, stroke: #2962FF, fill: #BBDEFB, color:#000000;\n",
+       "\tclassDef AppliedLoss stroke-width: 2px, stroke-dasharray: 0, stroke: #D50000, fill: #FFCDD2, color:#000000;\n",
+       "\n",
+       "\tclassDef DashMediumAnimation stroke-dasharray: 9,5, stroke-dashoffset: 100, animation: dash 3s linear infinite;\n",
+       "\tclassDef NoAnimation stroke-dasharray: 0;\n",
+       "\tclass e1 NoAnimation\n",
+       "\tclass e2 DashMediumAnimation\n",
+       "\tclass e3 DashMediumAnimation\n",
+       "\tclass e4 NoAnimation\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Option B: Using the from_split() convenience constructor\n",
     "# This auto-generates InputBindings for all active head nodes\n",
@@ -457,10 +661,53 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "id": "25",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "EvalPhase: eval\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "```{mermaid}\n",
+       "flowchart LR\n",
+       "\tn1 e0@-->|\"(1, 10) split: test\"| n0\n",
+       "\tn0 e1@-->|\"(1, 1)\"| n2\n",
+       "\tn3 e2@-.-> n0\n",
+       "\n",
+       "\tn0@{ label: \"<b>ModelNode</b><br>'MLP'  &lt;torch&gt;<br>──────────<br><b>features</b><br>  voltage<br><b>targets</b><br>  soh\", shape: rect }\n",
+       "\tn1@{ label: \"<b>FeatureSet</b><br>'SensorData'<br>n=500\", shape: rect }\n",
+       "\tn2@{ label: \" \", shape: circle }\n",
+       "\tn3@{ label: \"<b>AppliedLoss</b><br>'mse'<br>loss: mse\", shape: stadium }\n",
+       "\tn0:::ModelNodeFrozen\n",
+       "\tn1:::FeatureSet\n",
+       "\tn2:::OutputTerminal\n",
+       "\tn3:::AppliedLoss\n",
+       "\tclassDef ModelNodeFrozen stroke-width: 2px, stroke-dasharray: 0, stroke: #90CAF9, fill: #E3F2FD, color:#666666;\n",
+       "\tclassDef OutputTerminal stroke-width: 2px, stroke-dasharray: 0, stroke: #424242, fill: #616161, color:#FFFFFF;\n",
+       "\tclassDef FeatureSet stroke-width: 2px, stroke-dasharray: 0, stroke: #AA00FF, fill: #E1BEE7, color:#000000;\n",
+       "\tclassDef AppliedLoss stroke-width: 2px, stroke-dasharray: 0, stroke: #D50000, fill: #FFCDD2, color:#000000;\n",
+       "\n",
+       "\tclassDef NoAnimation stroke-dasharray: 0;\n",
+       "\tclass e0 NoAnimation\n",
+       "\tclass e1 NoAnimation\n",
+       "\tclass e2 NoAnimation\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Using the from_split() convenience constructor\n",
     "eval_phase = EvalPhase.from_split(\n",
@@ -521,10 +768,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "id": "29",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Execution plan: PhaseGroup(label=my_experiment, entries=0)\n",
+      "Currently empty: True\n"
+     ]
+    }
+   ],
    "source": [
     "# Access the execution plan\n",
     "plan = exp.execution_plan\n",
@@ -534,10 +790,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "id": "30",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Plan entries: 2\n",
+      "  [0] train (TrainPhase)\n",
+      "  [1] eval (EvalPhase)\n"
+     ]
+    }
+   ],
    "source": [
     "# Register phases in execution order\n",
     "plan.add_phase(train_phase)\n",
@@ -560,10 +826,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "id": "32",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "By index:  train\n",
+      "By label:  train\n",
+      "TrainPhase: train, EvalPhase: eval\n"
+     ]
+    }
+   ],
    "source": [
     "# By index\n",
     "first_phase = plan[0]\n",
@@ -591,10 +867,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "id": "34",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "After remove: ['train']\n",
+      "After re-add: ['train', 'eval']\n"
+     ]
+    }
+   ],
    "source": [
     "# Remove by label\n",
     "plan.remove_phase(\"eval\")\n",
@@ -662,10 +947,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "id": "39",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5d8dd278f95844b3a8619a09727048f5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training completed.\n",
+      "  History entries: 1\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Run the training phase\n",
     "train_results = exp.run_phase(train_phase)\n",
@@ -675,10 +993,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "id": "40",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2c53ce889752471fb63e15ad3e75a9cc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Run the evaluation phase\n",
     "eval_results = exp.run_phase(eval_phase)"
@@ -686,10 +1029,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "id": "41",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Evaluation completed.\n",
+      "  History entries: 2\n"
+     ]
+    }
+   ],
    "source": [
     "print(\"Evaluation completed.\")\n",
     "print(f\"  History entries: {len(exp.history)}\")"
@@ -742,10 +1094,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 42,
    "id": "45",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d60df45d37144ddfb808525a9942589b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Full run completed.\n",
+      "History entries: 4\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Run the full execution plan (train -> eval)\n",
     "results = exp.run()\n",
@@ -764,10 +1149,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "id": "47",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[TrainResults(label='train', epochs=3), EvalResults(label='eval', batches=1)]"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "results"
    ]
@@ -798,10 +1194,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 44,
    "id": "50",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "226187efb0044019aa1a6c06f098b406",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "History before: 4\n",
+      "History after:  4\n",
+      "State was restored: True\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "history_before = len(exp.history)\n",
     "\n",
@@ -846,10 +1276,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 45,
    "id": "54",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Run 0: label='train', status=completed, duration=0:00:00.116325\n",
+      "  Run 1: label='eval', status=completed, duration=0:00:00.029989\n",
+      "  Run 2: label='train', status=completed, duration=0:00:00.108046\n",
+      "  Run 3: label='eval', status=completed, duration=0:00:00.009087\n"
+     ]
+    }
+   ],
    "source": [
     "for i, run in enumerate(exp.history):\n",
     "    print(\n",
@@ -861,10 +1302,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 46,
    "id": "55",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Last run: eval\n",
+      "  Status:  completed\n",
+      "  Results: EvalResults\n"
+     ]
+    }
+   ],
    "source": [
     "# Access the most recent run\n",
     "last = exp.last_run\n",
@@ -936,10 +1387,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 47,
    "id": "59",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Save artifacts on disk? True\n",
+      "Save execution data on disk? True\n",
+      "Save metrics on disk? False\n"
+     ]
+    }
+   ],
    "source": [
     "from pathlib import Path\n",
     "from tempfile import TemporaryDirectory\n",
@@ -1005,10 +1466,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 48,
    "id": "61",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "12d7949cce56414d93e74c71b5c29632",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ALL -> execution contexts: 26\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LAST -> execution contexts: 13\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NONE -> execution contexts: 0\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "from modularml import ResultRecording\n",
     "\n",
@@ -1080,10 +1587,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 49,
    "id": "65",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Group: PhaseGroup(label=train_eval_cycle, entries=2)\n",
+      "Entries: ['cycle_train', 'cycle_eval']\n"
+     ]
+    }
+   ],
    "source": [
     "# Create a sub-group for a train-eval cycle\n",
     "cycle = PhaseGroup(label=\"train_eval_cycle\")\n",
@@ -1111,10 +1627,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 50,
    "id": "66",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ca61723453a34830b627e435449233e8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Group results: {'cycle_train': TrainResults(label='cycle_train', epochs=2), 'cycle_eval': EvalResults(label='cycle_eval', batches=1)}\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Run the group directly\n",
     "group_results = exp.run_group(cycle)\n",
@@ -1134,10 +1682,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 51,
    "id": "68",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Flattened: ['inner_train', 'outer_eval']\n"
+     ]
+    }
+   ],
    "source": [
     "# Build a nested plan\n",
     "outer = PhaseGroup(label=\"outer\")\n",
@@ -1318,10 +1874,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 52,
    "id": "78",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Checkpoint saved to: /tmp/tmpl7thf2lc/after_training.ckpt.mml\n",
+      "Available checkpoints: ['after_training']\n"
+     ]
+    }
+   ],
    "source": [
     "from pathlib import Path\n",
     "from tempfile import TemporaryDirectory\n",
@@ -1339,10 +1904,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 53,
    "id": "79",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Checkpoint restored.\n"
+     ]
+    }
+   ],
    "source": [
     "# Restore from a checkpoint (by name or path)\n",
     "exp.restore_checkpoint(\"after_training\")\n",
@@ -1393,10 +1966,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 54,
    "id": "84",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Experiment saved to: /tmp/tmpzq4b7av0/my_experiment.exp.mml\n"
+     ]
+    }
+   ],
    "source": [
     "SAVE_DIR = TemporaryDirectory()\n",
     "\n",
@@ -1419,10 +2000,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 55,
    "id": "86",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "─────────────────────────────── INFO - Node ID Collision ───────────────────────────────\n",
+      " Loaded FeatureSet is identical to 'SensorData' in the existing ExperimentContext.\n",
+      " Returning 'FeatureSet(label='SensorData', n_samples=500)'.\n",
+      "────────────────────────────────────────────────────────────────────────────────────────\n",
+      "─────────────────────────────── INFO - Node ID Collision ───────────────────────────────\n",
+      " The loaded ModelNode has an overlapping ID with existing ModelNode 'MLP'. 'MLP' will\n",
+      " be overwritten in the active ExperimentContext.\n",
+      "────────────────────────────────────────────────────────────────────────────────────────\n",
+      "───────────────────────────── INFO - ModelGraph Collision ──────────────────────────────\n",
+      " Loaded ModelGraph is identical to 'SimpleGraph' in the existing ExperimentContext.\n",
+      " Returning 'SimpleGraph'.\n",
+      "────────────────────────────────────────────────────────────────────────────────────────\n",
+      "───────────────────────────────────── UserWarning ──────────────────────────────────────\n",
+      " The serialized experiment contains 1 checkpoint(s), but no `checkpoint_dir` was\n",
+      " provided to `Experiment.load()`. Checkpoints were not restored.\n",
+      "\n",
+      " Pass `checkpoint_dir=Path(...)` to `Experiment.load()` to extract checkpoints.\n",
+      "────────────────────────────────────────────────────────────────────────────────────────\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded experiment: my_experiment\n",
+      "  Model graph: ModelGraph(label='SimpleGraph', nodes=1, built=True, optimizer=Optimizer)\n"
+     ]
+    }
+   ],
    "source": [
     "# Load the experiment\n",
     "loaded_exp = Experiment.load(save_path, overwrite=True)\n",
@@ -1452,12 +2066,124 @@
    "id": "88",
    "metadata": {},
    "source": [
+    "### Saving Without FeatureSet Data\n",
+    "\n",
+    "For large datasets, bundling the full FeatureSet into the experiment archive can be\n",
+    "prohibitively expensive. Pass `include_featuresets=False` to omit raw data from the\n",
+    "save. The experiment still records enough structural metadata (schema, split configs,\n",
+    "scaler configs, and the FeatureSet UUID) to validate and reattach the data on load.\n",
+    "\n",
+    "The FeatureSet must be saved separately beforehand so it can be provided at load time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "id": "89",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FeatureSet saved to: /tmp/tmp6a_yrc5f/SensorData.fs.mml\n",
+      "Experiment (slim) saved to: /tmp/tmptqqy0kns/my_experiment_slim.exp.mml\n"
+     ]
+    }
+   ],
+   "source": [
+    "FS_SAVE_DIR = TemporaryDirectory()\n",
+    "EXP_SAVE_DIR = TemporaryDirectory()\n",
+    "\n",
+    "# Save the FeatureSet independently\n",
+    "fs_path = fs.save(Path(FS_SAVE_DIR.name) / \"SensorData\", overwrite=True)\n",
+    "print(f\"FeatureSet saved to: {fs_path}\")\n",
+    "\n",
+    "# Save the experiment without bundling the FeatureSet raw data\n",
+    "slim_exp_path = exp.save(\n",
+    "    Path(EXP_SAVE_DIR.name) / \"my_experiment_slim\",\n",
+    "    include_featuresets=False,\n",
+    "    overwrite=True,\n",
+    ")\n",
+    "print(f\"Experiment (slim) saved to: {slim_exp_path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "90",
+   "metadata": {},
+   "source": [
+    "To reload a slim experiment, pass the FeatureSet back via the `featuresets` argument.\n",
+    "Each entry can be a `FeatureSet` instance or a path to a saved FeatureSet artifact.\n",
+    "\n",
+    "The framework matches each stub by **label**, validates structural compatibility\n",
+    "(columns, dtypes, shapes, sample count, split labels), and resets the FeatureSet's\n",
+    "UUID to match what the saved experiment graph expects so all model graph references resolve correctly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "id": "91",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "─────────────────────────────── INFO - Node ID Collision ───────────────────────────────\n",
+      " Loaded FeatureSet is identical to 'SensorData' in the existing ExperimentContext.\n",
+      " Returning 'FeatureSet(label='SensorData', n_samples=500)'.\n",
+      "────────────────────────────────────────────────────────────────────────────────────────\n",
+      "─────────────────────────────── INFO - Node ID Collision ───────────────────────────────\n",
+      " The loaded ModelNode has an overlapping ID with existing ModelNode 'MLP'. 'MLP' will\n",
+      " be overwritten in the active ExperimentContext.\n",
+      "────────────────────────────────────────────────────────────────────────────────────────\n",
+      "───────────────────────────── INFO - ModelGraph Collision ──────────────────────────────\n",
+      " Loaded ModelGraph is identical to 'SimpleGraph' in the existing ExperimentContext.\n",
+      " Returning 'SimpleGraph'.\n",
+      "────────────────────────────────────────────────────────────────────────────────────────\n",
+      "───────────────────────────────────── UserWarning ──────────────────────────────────────\n",
+      " The serialized experiment contains 1 checkpoint(s), but no `checkpoint_dir` was\n",
+      " provided to `Experiment.load()`. Checkpoints were not restored.\n",
+      "\n",
+      " Pass `checkpoint_dir=Path(...)` to `Experiment.load()` to extract checkpoints.\n",
+      "────────────────────────────────────────────────────────────────────────────────────────\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded experiment: my_experiment\n",
+      "  FeatureSet: FeatureSet(label='SensorData', n_samples=500)\n",
+      "  Model graph: ModelGraph(label='SimpleGraph', nodes=1, built=True, optimizer=Optimizer)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Load with a FeatureSet path — the framework validates schema and reattaches\n",
+    "loaded_slim = Experiment.load(\n",
+    "    slim_exp_path,\n",
+    "    featuresets=[fs_path],  # can also pass a FeatureSet instance directly\n",
+    "    overwrite=True,\n",
+    ")\n",
+    "print(f\"Loaded experiment: {loaded_slim.label}\")\n",
+    "print(f\"  FeatureSet: {loaded_slim.featureset!r}\")\n",
+    "print(f\"  Model graph: {loaded_slim.model_graph!r}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "92",
+   "metadata": {},
+   "source": [
     "---"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "89",
+   "id": "93",
    "metadata": {},
    "source": [
     "(05-create-experiment-summary)=\n",
@@ -1466,7 +2192,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "90",
+   "id": "94",
    "metadata": {},
    "source": [
     "### Experiment Constructor\n",
@@ -1541,7 +2267,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "91",
+   "id": "95",
    "metadata": {},
    "source": [
     "### Next Steps\n",

--- a/modularml/__init__.py
+++ b/modularml/__init__.py
@@ -3,6 +3,7 @@ from modularml.api import (
     AppliedLoss,
     BaseModel,
     CVBinding,
+    CVResults,
     Checkpointing,
     ConcatNode,
     CrossValidation,

--- a/modularml/__init__.py
+++ b/modularml/__init__.py
@@ -8,6 +8,7 @@ from modularml.api import (
     ConcatNode,
     CrossValidation,
     EarlyStopping,
+    EmptyExperimentContextError,
     EvalLossMetric,
     EvalPhase,
     EvalResults,
@@ -21,6 +22,7 @@ from modularml.api import (
     Loss,
     ModelGraph,
     ModelNode,
+    NodeNotFoundError,
     Optimizer,
     PhaseGroup,
     PhaseGroupResults,
@@ -33,7 +35,9 @@ from modularml.api import (
     TorchBaseModel,
     TrainPhase,
     TrainResults,
+    configure,
     scaler_registry,
+    settings,
     supported_scalers,
 )
 from modularml.registry import register_all

--- a/modularml/api.py
+++ b/modularml/api.py
@@ -24,7 +24,7 @@ from modularml.core.experiment.phases.train_phase import ResultRecording
 # ================================================
 from modularml.core.execution.cross_validation.cross_validation import CrossValidation
 from modularml.core.execution.cross_validation.cv_binding import CVBinding
-
+from modularml.core.execution.cross_validation.cv_results import CVResults
 
 # ================================================
 # Callbacks
@@ -105,6 +105,7 @@ __all__ = [
     "Checkpointing",
     "ConcatNode",
     "CrossValidation",
+    "CVResults",
     "EarlyStopping",
     "EvalLossMetric",
     "EvalPhase",

--- a/modularml/api.py
+++ b/modularml/api.py
@@ -90,6 +90,16 @@ from modularml.core.transforms.scaler import Scaler
 from modularml.scalers import scaler_registry
 
 supported_scalers = Scaler.get_supported_scalers()
+
+# ================================================
+# Settings & Exceptions
+# ================================================
+from modularml.core.settings import configure, settings
+from modularml.utils.errors.exceptions import (
+    EmptyExperimentContextError,
+    NodeNotFoundError,
+)
+
 """
 All built-in transformed are accessed with:
 
@@ -102,10 +112,10 @@ __all__ = [
     "AppliedLoss",
     "BaseModel",
     "CVBinding",
+    "CVResults",
     "Checkpointing",
     "ConcatNode",
     "CrossValidation",
-    "CVResults",
     "EarlyStopping",
     "EvalLossMetric",
     "EvalPhase",

--- a/modularml/core/data/featureset.py
+++ b/modularml/core/data/featureset.py
@@ -915,7 +915,8 @@ class FeatureSet(ExperimentNode, SplitMixin, SampleCollectionMixin):
                 Split name from which to fit the scaler (e.g., "train"). If None, the \
                 scaler is fit to all samples. Defaults to None.
             merged_axes (int | tuple[int]):
-                Axes whose sizes are merged into a single dimension. If None, no axes are \
+                Axes whose sizes are merged into a single dimension. If a single value is given,
+                that axis shape is preserved, and all others are merged. If None, no axes are \
                 merged. An Error will be thrown if the resulting shape is not 2-dimensional.
 
         Raises:

--- a/modularml/core/data/featureset.py
+++ b/modularml/core/data/featureset.py
@@ -1332,6 +1332,26 @@ class FeatureSet(ExperimentNode, SplitMixin, SampleCollectionMixin):
 
         return new_fs
 
+    def get_schema_stub(self) -> dict[str, Any]:
+        """Schema metadata without raw data, used for lightweight experiment saves."""
+        return self.collection.get_schema_stub()
+
+    def matches_schema_stub(self, stub: dict[str, Any]) -> tuple[bool, str]:
+        """
+        Validate structural compatibility against a saved schema stub.
+
+        Returns (True, "") on match, (False, reason) on mismatch.
+        Does not validate UUID.
+        """
+        ok, msg = self.collection.matches_schema_stub(stub)
+        if not ok:
+            return False, msg
+        expected_splits = set(stub.get("split_labels", []))
+        actual_splits = set(self.available_splits)
+        if expected_splits and expected_splits != actual_splits:
+            return False, f"Split label mismatch: {actual_splits} != {expected_splits}"
+        return True, ""
+
     # ================================================
     # Referencing
     # ================================================

--- a/modularml/core/data/sample_collection.py
+++ b/modularml/core/data/sample_collection.py
@@ -1028,6 +1028,62 @@ class SampleCollection:
             include_domain_prefix=include_domain_prefix,
         )
 
+    def get_schema_stub(self) -> dict[str, Any]:
+        """
+        Return schema metadata without raw data.
+        
+        Meta data includes: columns, shapes, dtypes, n_sample.
+        """
+        stub: dict[str, Any] = {"n_samples": self.n_samples}
+        for domain in [DOMAIN_FEATURES, DOMAIN_TARGETS, DOMAIN_TAGS]:
+            domain_info: dict[str, dict[str, dict[str, Any]]] = {}
+            for key in self.schema.domain_keys(domain):
+                reps: dict[str, dict[str, Any]] = {}
+                for rep in self.schema.rep_keys(domain, key):
+                    reps[rep] = {
+                        "shape": list(self._get_rep_shape(domain, key, rep)),
+                        "dtype": self._get_rep_dtype(domain, key, rep),
+                    }
+                domain_info[key] = reps
+            stub[domain] = domain_info
+        return stub
+
+    def matches_schema_stub(self, stub: dict[str, Any]) -> tuple[bool, str]:
+        """
+        Validate that this collection's schema matches a saved stub.
+
+        Returns (True, "") on match, (False, reason) on mismatch.
+        """
+        if self.n_samples != stub.get("n_samples"):
+            return False, f"n_samples mismatch: {self.n_samples} != {stub['n_samples']}"
+        for domain in [DOMAIN_FEATURES, DOMAIN_TARGETS, DOMAIN_TAGS]:
+            expected = stub.get(domain, {})
+            actual_keys = set(self.schema.domain_keys(domain))
+            expected_keys = set(expected.keys())
+            if actual_keys != expected_keys:
+                return (
+                    False,
+                    f"{domain} column mismatch: {actual_keys} != {expected_keys}",
+                )
+            for key, reps in expected.items():
+                for rep, info in reps.items():
+                    actual_reps = set(self.schema.rep_keys(domain, key))
+                    if rep not in actual_reps:
+                        return False, f"Missing representation {domain}.{key}.{rep}"
+                    actual_shape = self._get_rep_shape(domain, key, rep)
+                    actual_dtype = self._get_rep_dtype(domain, key, rep)
+                    if tuple(info["shape"]) != actual_shape:
+                        return (
+                            False,
+                            f"Shape mismatch {domain}.{key}.{rep}: {actual_shape} != {tuple(info['shape'])}",
+                        )
+                    if info["dtype"] != actual_dtype:
+                        return (
+                            False,
+                            f"Dtype mismatch {domain}.{key}.{rep}: {actual_dtype} != {info['dtype']}",
+                        )
+        return True, ""
+
     # ================================================
     # Domain data accessors
     # ================================================

--- a/modularml/core/data/sample_collection.py
+++ b/modularml/core/data/sample_collection.py
@@ -1031,7 +1031,7 @@ class SampleCollection:
     def get_schema_stub(self) -> dict[str, Any]:
         """
         Return schema metadata without raw data.
-        
+
         Meta data includes: columns, shapes, dtypes, n_sample.
         """
         stub: dict[str, Any] = {"n_samples": self.n_samples}

--- a/modularml/core/execution/cross_validation/cross_validation.py
+++ b/modularml/core/execution/cross_validation/cross_validation.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -349,3 +349,51 @@ class CrossValidation(ExecutionStrategy):
         fold_ptask.finish()
 
         return all_res
+
+    # ================================================
+    # Configurable
+    # ================================================
+    def get_config(self) -> dict[str, Any]:
+        """
+        Return a serializable configuration dict for this cross-validation strategy.
+
+        Captures label, fold count, seed, all :class:`CVBinding` configurations,
+        and the resolved phase template. Does not capture runtime state.
+
+        Returns:
+            dict[str, Any]: Configuration sufficient to reconstruct this
+                :class:`CrossValidation` via :meth:`from_config`.
+
+        """
+        return {
+            "label": self.label,
+            "bindings": [b.get_config() for b in self.bindings.values()],
+            "n_folds": self.n_folds,
+            "seed": self.seed,
+            "phase_template": self.phase_template.get_config(),
+        }
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> CrossValidation:
+        """
+        Reconstruct a :class:`CrossValidation` from a configuration dict.
+
+        All :class:`FeatureSet` nodes referenced in the bindings must already
+        be registered in the active :class:`ExperimentContext`.
+
+        Args:
+            config (dict[str, Any]): Dict produced by :meth:`get_config`.
+
+        Returns:
+            CrossValidation: Reconstructed cross-validation strategy.
+
+        """
+        bindings = [CVBinding.from_config(b) for b in config["bindings"]]
+        phase_template = PhaseGroup.from_config(config["phase_template"])
+        return cls(
+            label=config["label"],
+            bindings=bindings,
+            n_folds=config["n_folds"],
+            seed=config["seed"],
+            phase=phase_template,
+        )

--- a/modularml/core/execution/cross_validation/cv_binding.py
+++ b/modularml/core/execution/cross_validation/cv_binding.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from modularml.core.data.featureset import FeatureSet
 from modularml.core.experiment.experiment_context import ExperimentContext
@@ -115,6 +115,53 @@ class CVBinding:
                 "produced by each fold will not be used. "
             )
             warn(message=msg, stacklevel=2)
+
+    # ================================================
+    # Serialization
+    # ================================================
+    def get_config(self) -> dict[str, Any]:
+        """
+        Return a serializable configuration dict for this binding.
+
+        Returns:
+            dict[str, Any]: Configuration sufficient to reconstruct this
+                :class:`CVBinding` via :meth:`from_config`.
+
+        """
+        return {
+            "fs": self._fs_id,
+            "source_splits": self.source_splits,
+            "group_by": self.group_by,
+            "stratify_by": self.stratify_by,
+            "train_split_name": self.train_split_name,
+            "val_split_name": self.val_split_name,
+            "val_size": self.val_size,
+        }
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> CVBinding:
+        """
+        Reconstruct a :class:`CVBinding` from a configuration dict.
+
+        The :class:`FeatureSet` referenced by ``config["fs"]`` (node ID) must
+        already be registered in the active :class:`ExperimentContext`.
+
+        Args:
+            config (dict[str, Any]): Dict produced by :meth:`get_config`.
+
+        Returns:
+            CVBinding: Reconstructed binding.
+
+        """
+        return cls(
+            fs=config["fs"],
+            source_splits=config["source_splits"],
+            group_by=config.get("group_by"),
+            stratify_by=config.get("stratify_by"),
+            train_split_name=config.get("train_split_name", "train"),
+            val_split_name=config.get("val_split_name", "val"),
+            val_size=config.get("val_size"),
+        )
 
 
 @dataclass

--- a/modularml/core/execution/cross_validation/cv_results.py
+++ b/modularml/core/execution/cross_validation/cv_results.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, TypeVar
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from modularml.core.experiment.results.group_results import PhaseGroupResults
 from modularml.core.experiment.results.train_results import TrainResults
@@ -67,6 +69,84 @@ class CVResults(PhaseGroupResults):
     # ================================================
     def __repr__(self):
         return f"CVResults(label='{self.label}', n_folds={self.n_folds})"
+
+    # ================================================
+    # Configurable
+    # ================================================
+    def get_config(self) -> dict[str, Any]:
+        """Return a configuration dict sufficient to reconstruct an empty shell."""
+        return {"label": self.label}
+
+    @classmethod
+    def from_config(cls, config: dict[str, Any]) -> CVResults:
+        """Create an empty :class:`CVResults` from a configuration dict."""
+        return cls(label=config["label"])
+
+    # ================================================
+    # Stateful
+    # ================================================
+    def get_state(self) -> dict[str, Any]:
+        """Return a deep copy of the fold results."""
+        return {"results": deepcopy(self._results)}
+
+    def set_state(self, state: dict[str, Any]) -> None:
+        """Restore fold results from :meth:`get_state` output."""
+        self._results = state["results"]
+
+    # ================================================
+    # Serialization
+    # ================================================
+    def save(self, filepath: Path, *, overwrite: bool = False) -> Path:
+        """
+        Serialize this :class:`CVResults` to the specified filepath.
+
+        Args:
+            filepath (Path):
+                File location to save to. The suffix is enforced to
+                ``.<kind>.mml`` automatically.
+            overwrite (bool, optional):
+                Whether to overwrite any existing file. Defaults to False.
+
+        Returns:
+            Path: The actual filepath at which the results were saved.
+
+        """
+        from modularml.core.io.serialization_policy import SerializationPolicy
+        from modularml.core.io.serializer import serializer
+
+        return serializer.save(
+            self,
+            filepath,
+            policy=SerializationPolicy.BUILTIN,
+            overwrite=overwrite,
+        )
+
+    @classmethod
+    def load(
+        cls,
+        filepath: Path,
+        *,
+        allow_packaged_code: bool = False,
+    ) -> CVResults:
+        """
+        Load a :class:`CVResults` from file.
+
+        Args:
+            filepath (Path):
+                File location of previously saved :class:`CVResults`.
+            allow_packaged_code (bool, optional):
+                Whether bundled code execution is allowed. Defaults to False.
+
+        Returns:
+            CVResults: The reloaded results.
+
+        """
+        from modularml.core.io.serializer import _enforce_file_suffix, serializer
+
+        if Path(filepath).suffix == "":
+            filepath = _enforce_file_suffix(path=filepath, cls=cls)
+
+        return serializer.load(filepath, allow_packaged_code=allow_packaged_code)
 
     # ================================================
     # Properties

--- a/modularml/core/experiment/experiment.py
+++ b/modularml/core/experiment/experiment.py
@@ -280,6 +280,40 @@ class Experiment:
         return list(self._exp_callbacks)
 
     # ================================================
+    # Execution Plan Management
+    # ================================================
+    def set_execution_plan(
+        self,
+        phases: list[ExperimentPhase | PhaseGroup],
+        *,
+        overwrite: bool = False,
+    ) -> None:
+        """
+        Set the execution plan from a list of phases and/or phase groups.
+
+        Replaces the current execution plan with the provided items, preserving
+        their order.
+
+        Args:
+            phases (list[ExperimentPhase | PhaseGroup]):
+                Ordered list of phases and/or phase groups to execute.
+            overwrite (bool, optional):
+                If ``True``, replace a non-empty execution plan. If ``False``
+                and the plan already contains items, a `ValueError` is
+                raised. Defaults to ``False``.
+
+        Raises:
+            ValueError: If the execution plan is not empty and
+                ``overwrite=False``.
+
+        """
+        if self._exec_plan.all and not overwrite:
+            msg = "The execution plan is not empty. Pass overwrite=True to replace it."
+            raise ValueError(msg)
+        self._exec_plan.clear()
+        self._exec_plan.add_items(phases)
+
+    # ================================================
     # Experiment Callback Management
     # ================================================
     def add_callback(self, callback: ExperimentCallback) -> None:

--- a/modularml/core/experiment/experiment.py
+++ b/modularml/core/experiment/experiment.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
     from modularml.core.data.execution_context import ExecutionContext
     from modularml.core.experiment.results.phase_results import PhaseResults
     from modularml.core.topology.model_graph import ModelGraph
+    from modularml.core.data.featureset import FeatureSet
 
 logger = get_logger(name="Experiment")
 
@@ -248,6 +249,19 @@ class Experiment:
     def model_graph(self) -> ModelGraph | None:
         """Gets the ModelGraph associated with this Experiment."""
         return self._ctx.model_graph
+    
+    @property
+    def featureset(self) -> FeatureSet | list[FeatureSet]:
+        """
+        Retrieves the FeatureSet(s) associated with this experiment.
+        
+        If only one FeatureSet exists, it is returned directly. Otherwise,
+        a list of all available FeatureSets is returned
+        """
+        all_fs = list(self.ctx.available_featuresets.values())
+        if len(all_fs) == 1:
+            return all_fs[0]
+        return all_fs            
 
     @property
     def execution_plan(self) -> PhaseGroup:

--- a/modularml/core/experiment/experiment.py
+++ b/modularml/core/experiment/experiment.py
@@ -45,9 +45,9 @@ from modularml.utils.logging.warnings import warn
 
 if TYPE_CHECKING:
     from modularml.core.data.execution_context import ExecutionContext
+    from modularml.core.data.featureset import FeatureSet
     from modularml.core.experiment.results.phase_results import PhaseResults
     from modularml.core.topology.model_graph import ModelGraph
-    from modularml.core.data.featureset import FeatureSet
 
 logger = get_logger(name="Experiment")
 
@@ -249,19 +249,19 @@ class Experiment:
     def model_graph(self) -> ModelGraph | None:
         """Gets the ModelGraph associated with this Experiment."""
         return self._ctx.model_graph
-    
+
     @property
     def featureset(self) -> FeatureSet | list[FeatureSet]:
         """
         Retrieves the FeatureSet(s) associated with this experiment.
-        
+
         If only one FeatureSet exists, it is returned directly. Otherwise,
         a list of all available FeatureSets is returned
         """
         all_fs = list(self.ctx.available_featuresets.values())
         if len(all_fs) == 1:
             return all_fs[0]
-        return all_fs            
+        return all_fs
 
     @property
     def execution_plan(self) -> PhaseGroup:
@@ -1665,7 +1665,13 @@ class Experiment:
     # ================================================
     # Serialization
     # ================================================
-    def save(self, filepath: Path, *, overwrite: bool = False) -> Path:
+    def save(
+        self,
+        filepath: Path,
+        *,
+        overwrite: bool = False,
+        include_featuresets: bool = True,
+    ) -> Path:
         """
         Serializes this experiment to the specified filepath.
 
@@ -1676,6 +1682,11 @@ class Experiment:
             overwrite (bool, optional):
                 Whether to overwrite any existing file at the save location.
                 Defaults to False.
+            include_featuresets (bool, optional):
+                Whether to bundle full FeatureSet data in the artifact. When
+                False, only lightweight structural metadata (schema, splits,
+                scalers) is saved and the FeatureSets must be supplied via the
+                ``featuresets`` argument of :meth:`load`. Defaults to True.
 
         Returns:
             Path: The actual filepath at which the experiment was saved.
@@ -1689,6 +1700,7 @@ class Experiment:
             filepath,
             policy=SerializationPolicy.BUILTIN,
             overwrite=overwrite,
+            extras={"include_featuresets": include_featuresets},
         )
 
     @classmethod
@@ -1696,6 +1708,7 @@ class Experiment:
         cls,
         filepath: Path,
         *,
+        featuresets: list[str | Path | FeatureSet] | None = None,
         checkpoint_dir: Path | None = None,
         results_dir: Path | None = None,
         allow_packaged_code: bool = False,
@@ -1707,6 +1720,13 @@ class Experiment:
         Args:
             filepath (Path):
                 File location of a previously saved Experiment.
+            featuresets (list[str | Path | FeatureSet] | None, optional):
+                FeatureSets to inject when the experiment was saved with
+                ``include_featuresets=False``. Each entry is either a
+                :class:`FeatureSet` instance or a path to a saved FeatureSet
+                artifact. Each provided FeatureSet is matched to the saved
+                stub by label and validated for structural compatibility.
+                Defaults to None.
             checkpoint_dir (Path | None, optional):
                 Directory to extract saved checkpoints into. If the
                 serialized experiment contains checkpoint artifacts and
@@ -1737,7 +1757,9 @@ class Experiment:
         if Path(filepath).suffix == "":
             filepath = _enforce_file_suffix(path=filepath, cls=cls)
 
-        extras: dict = {}
+        extras: dict[str, Any] = {}
+        if featuresets is not None:
+            extras["featuresets"] = featuresets
         if checkpoint_dir is not None:
             extras["checkpoint_dir"] = checkpoint_dir
         if results_dir is not None:

--- a/modularml/core/experiment/experiment_context.py
+++ b/modularml/core/experiment/experiment_context.py
@@ -10,6 +10,10 @@ from typing import TYPE_CHECKING, Any
 from weakref import ref
 
 from modularml.utils.environment.environment import IN_NOTEBOOK
+from modularml.utils.errors.exceptions import (
+    EmptyExperimentContextError,
+    NodeNotFoundError,
+)
 from modularml.utils.logging.warnings import warn
 
 if TYPE_CHECKING:
@@ -106,7 +110,7 @@ class ExperimentContext:
         """
         ctx = _ACTIVE_EXPERIMENT_CONTEXT.get()
         if ctx is None:
-            raise RuntimeError("There is no active ExperimentContext.")
+            raise EmptyExperimentContextError
         return ctx
 
     @contextmanager
@@ -180,19 +184,26 @@ class ExperimentContext:
 
         Priority (highest to lowest):
             1. Environment variable
-            2. Jupyter notebook detection
-            3. Script default
+            2. Package-level ``settings.require_unique_labels``
+            3. Jupyter notebook detection
+            4. Script default
         """
         # 1. Explicit env override
         env = os.getenv("MODULARML_EXP_REGISTRATION_POLICY")
         if env:
             return RegistrationPolicy.from_value(env)
 
-        # 2. If running in Jupyter Notebook -> default to OVERWRITE_WARN
+        # 2. Package-level setting
+        from modularml.core.settings import settings
+
+        if settings.require_unique_labels:
+            return RegistrationPolicy.ERROR
+
+        # 3. If running in Jupyter Notebook -> default to OVERWRITE_WARN
         if IN_NOTEBOOK:
             return RegistrationPolicy.OVERWRITE_WARN
 
-        # 3. Else --> default to ERROR
+        # 4. Else --> default to ERROR
         return RegistrationPolicy.ERROR
 
     def set_registration_policy(self, policy: str | RegistrationPolicy):
@@ -386,7 +397,7 @@ class ExperimentContext:
             if node_id is None:
                 if error_if_missing:
                     msg = f"No ExperimentNode with label '{label}'."
-                    raise KeyError(msg)
+                    raise NodeNotFoundError(msg)
                 return None
 
         # Remove node
@@ -394,7 +405,7 @@ class ExperimentContext:
         if node is None:
             if error_if_missing:
                 msg = f"No ExperimentNode with id '{node_id}'."
-                raise KeyError(msg)
+                raise NodeNotFoundError(msg)
             return None
 
         # Remove label mapping
@@ -541,7 +552,7 @@ class ExperimentContext:
                 node = self._nodes_by_id[node_id]
             except KeyError as exc:
                 msg = f"No ExperimentNode with id '{node_id}'"
-                raise KeyError(msg) from exc
+                raise NodeNotFoundError(msg) from exc
 
         # Get node from label
         elif label is not None:
@@ -552,7 +563,7 @@ class ExperimentContext:
                 node = self._nodes_by_id[self._node_label_to_id[label]]
             except KeyError as exc:
                 msg = f"No ExperimentNode with label '{label}'"
-                raise KeyError(msg) from exc
+                raise NodeNotFoundError(msg) from exc
 
         else:
             raise ValueError("Must provide node_id or label.")

--- a/modularml/core/experiment/phases/phase.py
+++ b/modularml/core/experiment/phases/phase.py
@@ -167,6 +167,10 @@ class InputBinding:
     sampler: BaseSampler | None = None
     stream: str = STREAM_DEFAULT
 
+    def __post_init__(self):
+        # Ensure reference is enriched with current node data
+        self.upstream_ref.enrich_from_resolved()
+
     # ================================================
     # Constructors
     # ================================================

--- a/modularml/core/experiment/registry.py
+++ b/modularml/core/experiment/registry.py
@@ -1,5 +1,6 @@
 """Registration helpers for experiment symbols and serialization kinds."""
 
+from modularml.core.execution.cross_validation.cv_results import CVResults
 from modularml.core.experiment.experiment import Experiment
 from modularml.core.experiment.phases.phase_group import PhaseGroup
 from modularml.core.experiment.results.eval_results import EvalResults
@@ -70,6 +71,12 @@ def register_builtin():
         cls=TrainResults,
     )
 
+    # CV Results
+    symbol_registry.register_builtin_class(
+        key="CVResults",
+        cls=CVResults,
+    )
+
     # Experiment
     symbol_registry.register_builtin_class(
         key="Experiment",
@@ -79,6 +86,10 @@ def register_builtin():
 
 def register_kinds():
     """Register experiment serialization kinds."""
+    kind_registry.register(
+        cls=CVResults,
+        kind=SerializationKind(name="CVResults", kind="cvr"),
+    )
     kind_registry.register(
         cls=Experiment,
         kind=SerializationKind(name="Experiment", kind="exp"),

--- a/modularml/core/experiment/results/eval_results.py
+++ b/modularml/core/experiment/results/eval_results.py
@@ -151,16 +151,25 @@ class EvalResults(PhaseResults):
             ... )
 
         """
+        from modularml.utils.data.conversion import convert_to_format
+
+        # Collect in native format; defer conversion to after concat
         tensor_series = self.tensors(
             node=node,
             domain=domain,
             role=role,
-            fmt=fmt,
+            fmt=None,
             unscale=unscale,
         )
-        # Collapse batch axis, then get single value (only epoch=0)
+        
+        # Single concat across all batches
         collapsed = tensor_series.collapse(axis="batch", reducer="concat")
-        return collapsed.one()
+        result = collapsed.one()
+
+        # Format conversion
+        if fmt is not None:
+            result = convert_to_format(result, fmt=fmt)
+        return result
 
     def stacked_batches(
         self,
@@ -200,10 +209,10 @@ class EvalResults(PhaseResults):
         batch_series = self.batches(node=node)
         batches = list(batch_series.values())
 
+        merged_batch = Batch.concat(*batches)
         if fmt is not None:
-            batches = [b.to_format(fmt) for b in batches]
-
-        return Batch.concat(*batches, fmt=fmt)
+            merged_batch = merged_batch.to_format(fmt)
+        return merged_batch
 
     def aggregated_losses(
         self,

--- a/modularml/core/experiment/results/eval_results.py
+++ b/modularml/core/experiment/results/eval_results.py
@@ -161,7 +161,7 @@ class EvalResults(PhaseResults):
             fmt=None,
             unscale=unscale,
         )
-        
+
         # Single concat across all batches
         collapsed = tensor_series.collapse(axis="batch", reducer="concat")
         result = collapsed.one()

--- a/modularml/core/experiment/results/group_results.py
+++ b/modularml/core/experiment/results/group_results.py
@@ -328,26 +328,18 @@ class PhaseGroupResults:
 
         Description:
             Recursively unravels the hierarchy of PhaseGroupResults into
-            a flat mapping of phase labels to their PhaseResults. The
-            returned dict preserves execution order.
+            a flat mapping of phase labels to their PhaseResults.
 
             All phase labels must be unique across the entire hierarchy.
             If duplicate labels are found, a ValueError is raised.
 
         Returns:
             dict[str, PhaseResults]:
-                A flat mapping of phase labels to results in execution order.
+                A flat mapping of phase labels to results.
 
         Raises:
             ValueError:
                 If duplicate phase labels exist across the hierarchy.
-
-        Example:
-            All internal PhaseResults can be flattened to a single list:
-
-            >>> flat = group_results.flatten()  # doctest: +SKIP
-            >>> for label, phase_res in flat.items():  # doctest: +SKIP
-            ...     print(f"{label}: {type(phase_res).__name__}")
 
         """
         flat: dict[str, PhaseResults] = {}

--- a/modularml/core/experiment/results/phase_results.py
+++ b/modularml/core/experiment/results/phase_results.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from modularml.callbacks.artifact_result import ArtifactResult
+    from modularml.callbacks.early_stopping import EarlyStoppingResult
     from modularml.callbacks.evaluation import EvaluationCallbackResult
     from modularml.callbacks.metric import MetricResult
     from modularml.core.data.featureset import FeatureSet
@@ -742,6 +743,11 @@ class PhaseResults:
 
     @overload
     def callbacks(self, *, kind: Literal["payload"]) -> AxisSeries[PayloadResult]: ...
+
+    @overload
+    def callbacks(
+        self, *, kind: Literal["early_stopping"]
+    ) -> AxisSeries[EarlyStoppingResult]: ...
 
     @overload
     def callbacks(self, *, kind: None = ...) -> CallbackDataSeries: ...

--- a/modularml/core/experiment/results/phase_results.py
+++ b/modularml/core/experiment/results/phase_results.py
@@ -25,6 +25,10 @@ from modularml.core.training.loss_record import LossRecord
 from modularml.utils.data.data_format import DataFormat, normalize_format
 from modularml.utils.data.multi_keyed_data import AxisSeries
 from modularml.utils.data.scaling import unscale_sample_data
+from modularml.utils.errors.exceptions import (
+    EmptyExperimentContextError,
+    NodeNotFoundError,
+)
 from modularml.utils.topology.graph_search_utils import find_upstream_featuresets
 
 if TYPE_CHECKING:
@@ -41,6 +45,23 @@ if TYPE_CHECKING:
     from modularml.core.experiment.callbacks.callback_result import PayloadResult
 
 T = TypeVar("T")
+
+
+# ================================================
+# Offline Node Stub
+# ================================================
+@dataclass(frozen=True)
+class _SnapshotGraphNode:
+    """
+    Minimal stand-in for GraphNode when querying offline-loaded results.
+
+    Used by :meth:`PhaseResults._resolve_node` when no active
+    :class:`ExperimentContext` is available. Satisfies the ``.node_id`` and
+    ``.label`` duck-type contract required by query methods.
+    """
+
+    node_id: str
+    label: str
 
 
 # ================================================
@@ -268,6 +289,15 @@ class PhaseResults:
         repr=False,
     )
 
+    # Snapshot of {node_id -> label} populated at recording time (always has active
+    # context)
+    # Enables offline querying of results without a live ExperimentContext
+    _node_id_to_label: dict[str, str] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+    )
+
     def __post_init__(self) -> None:
         # ArtifactStore, CallbackStore, ExecutionStore, and MetricStore are computed
         # fields, not dataclass fields. Initialized here from their resolved storage
@@ -276,6 +306,11 @@ class PhaseResults:
         self._callback_store: CallbackStore = CallbackStore(location=self._callback_dir)
         self._execution: ExecutionStore = ExecutionStore(location=self._execution_dir)
         self._metrics: MetricStore = MetricStore(location=self._metric_dir)
+
+    def __setstate__(self, state: dict) -> None:
+        # Backward compatibility: old pickles lack _node_id_to_label
+        state.setdefault("_node_id_to_label", {})
+        self.__dict__.update(state)
 
     # ================================================
     # Runtime Modifiers
@@ -296,6 +331,33 @@ class PhaseResults:
         # Break any loss links too
         ctx.losses = ctx.losses.to_float()
 
+        # Populate node_id -> label snapshot while context is always active here
+        try:
+            exp_ctx = ExperimentContext.get_active()
+            for node_id in ctx.outputs:
+                if node_id not in self._node_id_to_label:
+                    try:
+                        gn = exp_ctx.get_node(node_id=node_id, enforce_type="GraphNode")
+                        self._node_id_to_label[node_id] = gn.label
+                    except NodeNotFoundError:
+                        pass
+            if ctx.losses is not None:
+                for lr in ctx.losses.values():
+                    if lr.node_id and lr.node_id not in self._node_id_to_label:
+                        if lr.node_label is not None:
+                            self._node_id_to_label[lr.node_id] = lr.node_label
+                        else:
+                            try:
+                                gn = exp_ctx.get_node(
+                                    node_id=lr.node_id,
+                                    enforce_type="GraphNode",
+                                )
+                                self._node_id_to_label[lr.node_id] = gn.label
+                            except NodeNotFoundError:
+                                pass
+        except EmptyExperimentContextError:
+            pass
+
         # Record cleaned ctx
         self._execution.append(ctx)
         self._series_cache.clear()
@@ -314,16 +376,58 @@ class PhaseResults:
     # ================================================
     # Helpers
     # ================================================
-    def _resolve_node(self, node: str | GraphNode) -> GraphNode:
-        """Resolve a GraphNode from a string ID/label or GraphNode instance."""
-        exp_ctx = ExperimentContext.get_active()
-        if isinstance(node, str):
-            return exp_ctx.get_node(val=node, enforce_type="GraphNode")
-        if isinstance(node, GraphNode):
+    def _resolve_node(self, node: str | GraphNode) -> GraphNode | _SnapshotGraphNode:
+        """
+        Resolve a node reference to a GraphNode (or offline stub).
+
+        Accepts a :class:`GraphNode` instance, a node label, or a node ID string.
+        When an active :class:`ExperimentContext` exists, it is used for
+        resolution. When offline (no active context), falls back to the embedded
+        :attr:`_node_id_to_label` snapshot populated at recording time.
+
+        Raises:
+            NodeNotFoundError: If the node cannot be resolved from either the
+                active context or the offline snapshot.
+            TypeError: If ``node`` is not a string or GraphNode.
+
+        """
+        if isinstance(node, (GraphNode, _SnapshotGraphNode)):
             return node
-        msg = (
-            f"Invalid `node` type. Must be string or GraphNode. Received: {type(node)}."
-        )
+
+        if isinstance(node, str):
+            # Fast path: active context available
+            try:
+                exp_ctx = ExperimentContext.get_active()
+                return exp_ctx.get_node(val=node, enforce_type="GraphNode")
+            except (EmptyExperimentContextError, NodeNotFoundError):
+                pass  # Offline: fall through to snapshot
+
+            # Offline: check if `node` matches a known node_id directly
+            if node in self._node_id_to_label:
+                return _SnapshotGraphNode(
+                    node_id=node,
+                    label=self._node_id_to_label[node],
+                )
+
+            # Offline: check if `node` matches a known label
+            label_to_id = {v: k for k, v in self._node_id_to_label.items()}
+            if node in label_to_id:
+                return _SnapshotGraphNode(
+                    node_id=label_to_id[node],
+                    label=node,
+                )
+
+            known = list(self._node_id_to_label.values()) or list(
+                self._node_id_to_label.keys(),
+            )
+            msg = (
+                f"Cannot resolve node '{node}': no active ExperimentContext and "
+                f"'{node}' is not in the embedded node snapshot. "
+                f"Known nodes: {known}."
+            )
+            raise NodeNotFoundError(msg)
+
+        msg = f"Invalid `node` type. Must be str or GraphNode. Received: {type(node)}."
         raise TypeError(msg)
 
     def _cache_get(self, key: tuple[Hashable, ...]):
@@ -413,7 +517,15 @@ class PhaseResults:
 
         # Trace upstream FeatureSets and create filtered views
         upstream_refs = find_upstream_featuresets(node=graph_node)
-        exp_ctx = ExperimentContext.get_active()
+        try:
+            exp_ctx = ExperimentContext.get_active()
+        except EmptyExperimentContextError as exc:
+            msg = (
+                "source_views() requires an active ExperimentContext to trace "
+                "upstream FeatureSets. Load or reconstruct the experiment before "
+                "calling this method."
+            )
+            raise EmptyExperimentContextError(msg) from exc
 
         views: dict[str, FeatureSetView] = {}
         uuid_list = list(all_uuids)
@@ -746,7 +858,9 @@ class PhaseResults:
 
     @overload
     def callbacks(
-        self, *, kind: Literal["early_stopping"]
+        self,
+        *,
+        kind: Literal["early_stopping"],
     ) -> AxisSeries[EarlyStoppingResult]: ...
 
     @overload

--- a/modularml/core/experiment/results/train_results.py
+++ b/modularml/core/experiment/results/train_results.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
 
 from modularml.core.experiment.results.phase_results import PhaseResults
+
+if TYPE_CHECKING:
+    from modularml.callbacks.early_stopping import EarlyStoppingResult
 
 
 @dataclass
@@ -64,3 +68,75 @@ class TrainResults(PhaseResults):
 
         """
         return len(self.epoch_indices)
+
+    # ================================================
+    # EarlyStopping Convenience
+    # ================================================
+    @property
+    def early_stopping_result(self) -> EarlyStoppingResult | None:
+        """
+        Return the EarlyStoppingResult recorded at phase end, if present.
+
+        Returns:
+            EarlyStoppingResult | None:
+                The result emitted by an :class:`EarlyStopping` callback,
+                or ``None`` if no such callback was attached to this phase.
+
+        """
+        values = self.callbacks(kind="early_stopping").values()
+        return values[0] if values else None
+
+    def best_epoch(
+        self,
+        metric: str = "val_loss",
+        direction: Literal["min", "max"] = "min",
+    ) -> int:
+        """
+        Return the epoch index at which ``metric`` was best.
+
+        Args:
+            metric (str): Name of the metric to inspect (e.g. ``"val_loss"``).
+                Defaults to ``"val_loss"``.
+            direction (Literal["min", "max"]): Whether a lower (``"min"``) or
+                higher (``"max"``) value is considered better. Defaults to
+                ``"min"``.
+
+        Returns:
+            int: Epoch index at which ``metric`` achieved its best value.
+
+        Raises:
+            ValueError: If ``metric`` is not found in the recorded metrics.
+
+        """
+        available = self.metric_names()
+        if metric not in available:
+            msg = (
+                f"Metric '{metric}' not found. "
+                f"Available metrics: {available}."
+            )
+            raise ValueError(msg)
+
+        entries = self.metrics().where(name=metric).values()
+        best_entry = min(entries, key=lambda e: e.value) if direction == "min" else max(entries, key=lambda e: e.value)
+        return best_entry.epoch_idx
+
+    @property
+    def last_epoch(self) -> int | None:
+        """
+        The epoch the model is currently at after training.
+
+        If an :class:`EarlyStopping` callback with ``restore_best=True`` ran
+        and successfully restored model weights, this returns the restored
+        (best) epoch. Otherwise, returns the last recorded epoch index.
+        Returns ``None`` if no epochs were recorded.
+
+        Returns:
+            int | None: Current model-state epoch, or ``None``.
+
+        """
+        es = self.early_stopping_result
+        if es is not None and es.restored and es.best_epoch is not None:
+            return es.best_epoch
+        if self.epoch_indices:
+            return self.epoch_indices[-1]
+        return None

--- a/modularml/core/experiment/results/train_results.py
+++ b/modularml/core/experiment/results/train_results.py
@@ -110,14 +110,15 @@ class TrainResults(PhaseResults):
         """
         available = self.metric_names()
         if metric not in available:
-            msg = (
-                f"Metric '{metric}' not found. "
-                f"Available metrics: {available}."
-            )
+            msg = f"Metric '{metric}' not found. Available metrics: {available}."
             raise ValueError(msg)
 
         entries = self.metrics().where(name=metric).values()
-        best_entry = min(entries, key=lambda e: e.value) if direction == "min" else max(entries, key=lambda e: e.value)
+        best_entry = (
+            min(entries, key=lambda e: e.value)
+            if direction == "min"
+            else max(entries, key=lambda e: e.value)
+        )
         return best_entry.epoch_idx
 
     @property

--- a/modularml/core/io/handlers/experiment_handler.py
+++ b/modularml/core/io/handlers/experiment_handler.py
@@ -507,9 +507,7 @@ def _inject_featureset(
     *,
     allow_packaged_code: bool,
 ) -> None:
-    """
-    Locate the FeatureSet matching ``stub``, validate its schema, and register it in ``exp_ctx`` under the UUID the experiment expects.
-    """
+    """Locate the FeatureSet matching ``stub``, validate its schema, and register it in ``exp_ctx`` under the UUID the experiment expects."""
     expected_node_id: str = stub["node_id"]
     expected_label: str = stub["label"]
     schema_stub: dict[str, Any] = stub["schema_stub"]

--- a/modularml/core/io/handlers/experiment_handler.py
+++ b/modularml/core/io/handlers/experiment_handler.py
@@ -44,7 +44,7 @@ class ExperimentHandler(BaseHandler["Experiment"]):
         obj: Experiment,
         save_dir: Path,
         *,
-        ctx: SaveContext,  # noqa: ARG002
+        ctx: SaveContext,
     ) -> dict[str, Any]:
         """
         Encode :class:`Experiment` dependencies and runtime state.
@@ -68,19 +68,39 @@ class ExperimentHandler(BaseHandler["Experiment"]):
         # ------------------------------------------------
         # 1. Save FeatureSets as sub-artifacts
         # ------------------------------------------------
+        include_featuresets: bool = ctx.extras.get("include_featuresets", True)
         featuresets = obj.ctx.available_featuresets
         if featuresets:
             fs_dir = save_dir / "featuresets"
             fs_dir.mkdir(exist_ok=True)
 
-            # Serialize each featureset
-            fs_entries: dict[str, str] = {}
-            for fs_id, fs in featuresets.items():
-                save_path = fs.save(filepath=(fs_dir / fs_id), overwrite=True)
-                fs_entries[fs_id] = str(Path(save_path).relative_to(save_dir))
-
-            # Mapping of each featureset to its serialized file
-            file_mapping["featuresets"] = fs_entries
+            if include_featuresets:
+                # Full artifact per FeatureSet
+                fs_entries: dict[str, str] = {}
+                for fs_id, fs in featuresets.items():
+                    save_path = fs.save(filepath=(fs_dir / fs_id), overwrite=True)
+                    fs_entries[fs_id] = str(Path(save_path).relative_to(save_dir))
+                file_mapping["featuresets"] = fs_entries
+            else:
+                # Lightweight: schema stub + split/scaler configs, no raw data
+                stub_entries: dict[str, str] = {}
+                for fs_id, fs in featuresets.items():
+                    stub: dict[str, Any] = {
+                        "node_id": fs.node_id,
+                        "label": fs.label,
+                        "schema_stub": fs.get_schema_stub(),
+                        "config": fs.get_config(),
+                        "split_labels": fs.available_splits,
+                        "split_indices": {
+                            k: v.indices.tolist() for k, v in fs._splits.items()
+                        },
+                        "split_recs": [rec.get_config() for rec in fs._split_recs],
+                        "scaler_recs": [rec.get_config() for rec in fs._scaler_recs],
+                    }
+                    stub_path = fs_dir / f"{fs_id}_stub.json"
+                    self._write_json(stub, stub_path)
+                    stub_entries[fs_id] = str(stub_path.relative_to(save_dir))
+                file_mapping["featureset_stubs"] = stub_entries
 
         # ------------------------------------------------
         # 2. Save ModelGraph as sub-artifact
@@ -259,16 +279,37 @@ class ExperimentHandler(BaseHandler["Experiment"]):
         # 1. Load FeatureSets
         # ------------------------------------------------
         fs_entries: dict[str, str] = file_mapping.get("featuresets", {})
-        for fs_rel_path in fs_entries.values():
-            # Get filepath to serialized object (.fs.mml file)
-            file_fs = load_dir / fs_rel_path
+        fs_stubs: dict[str, str] = file_mapping.get("featureset_stubs", {})
 
-            # Load featureset - this automatically registers to the active ctx
-            _ = FeatureSet.load(
-                filepath=file_fs,
-                allow_packaged_code=ctx.allow_packaged_code,
-                overwrite=ctx.overwrite_collision,
-            )
+        if fs_entries:
+            # Full featuresets saved
+            for fs_rel_path in fs_entries.values():
+                file_fs = load_dir / fs_rel_path
+                _ = FeatureSet.load(
+                    filepath=file_fs,
+                    allow_packaged_code=ctx.allow_packaged_code,
+                    overwrite=ctx.overwrite_collision,
+                )
+
+        elif fs_stubs:
+            # Lightweight stubs -> requires user-provided FeatureSets
+            provided: list[str | Path | FeatureSet] = ctx.extras.get("featuresets", [])
+            if not provided:
+                msg = (
+                    "This experiment was saved without FeatureSet data "
+                    "(include_featuresets=False). Provide the original FeatureSets "
+                    "via Experiment.load(..., featuresets=[...])."
+                )
+                raise ValueError(msg)
+
+            for stub_rel_path in fs_stubs.values():
+                stub_data: dict[str, Any] = self._read_json(load_dir / stub_rel_path)
+                _inject_featureset(
+                    stub=stub_data,
+                    provided=provided,
+                    exp_ctx=exp_ctx,
+                    allow_packaged_code=ctx.allow_packaged_code,
+                )
 
         # ------------------------------------------------
         # 2. Load ModelGraph (registers nodes + graph)
@@ -457,3 +498,75 @@ class ExperimentHandler(BaseHandler["Experiment"]):
                         pr._callback_dir = dest
 
                 pr._series_cache.clear()
+
+
+def _inject_featureset(
+    stub: dict[str, Any],
+    provided: list[str | Path | FeatureSet],
+    exp_ctx: Any,
+    *,
+    allow_packaged_code: bool,
+) -> None:
+    """
+    Locate the FeatureSet matching ``stub``, validate its schema, and register it in ``exp_ctx`` under the UUID the experiment expects.
+    """
+    expected_node_id: str = stub["node_id"]
+    expected_label: str = stub["label"]
+    schema_stub: dict[str, Any] = stub["schema_stub"]
+    expected_splits: list[str] = stub.get("split_labels", [])
+
+    matched_fs: FeatureSet | None = None
+    for item in provided:
+        if isinstance(item, (str, Path)):
+            candidate: FeatureSet = FeatureSet.load(
+                filepath=item,
+                allow_packaged_code=allow_packaged_code,
+                overwrite=False,
+            )
+        else:
+            candidate = item
+
+        if candidate.label != expected_label:
+            continue
+
+        ok, reason = candidate.matches_schema_stub(
+            {**schema_stub, "split_labels": expected_splits},
+        )
+        if not ok:
+            msg = (
+                f"Provided FeatureSet '{expected_label}' label matches but "
+                f"schema is incompatible: {reason}"
+            )
+            raise ValueError(msg)
+        matched_fs = candidate
+        break
+
+    if matched_fs is None:
+        available = [getattr(x, "label", str(x)) for x in provided]
+        msg = (
+            f"No provided FeatureSet matches label '{expected_label}'. "
+            f"Available labels: {available}"
+        )
+        raise ValueError(msg)
+
+    _reassign_and_register(
+        fs=matched_fs,
+        expected_node_id=expected_node_id,
+        ctx=exp_ctx,
+    )
+
+
+def _reassign_and_register(
+    fs: FeatureSet,
+    expected_node_id: str,
+    ctx: Any,
+) -> None:
+    """Mutate ``fs._node_id`` to match the UUID the experiment graph expects, then register in the active ExperimentContext."""
+    current_id = fs._node_id
+
+    if ctx.has_node(node_id=current_id):
+        ctx.remove_node(node_id=current_id, error_if_missing=False)
+
+    # Reassign UUID
+    fs._node_id = expected_node_id
+    ctx.register_experiment_node(fs)

--- a/modularml/core/io/serializer.py
+++ b/modularml/core/io/serializer.py
@@ -97,6 +97,7 @@ class SaveContext:
         artifact_path: Path,
         serializer: Serializer,
         mml_version: str = "1.0.0",
+        extras: dict[str, Any] | None = None,
     ):
         """
         Initialize a :class:`SaveContext`.
@@ -105,11 +106,13 @@ class SaveContext:
             artifact_path (Path): Root folder where artifacts are written.
             serializer (Serializer): Owning serializer instance.
             mml_version (str): Version string recorded in emitted manifests.
+            extras (dict[str, Any] | None): Additional metadata forwarded to handlers.
 
         """
         self.artifact_path = artifact_path
         self.serializer = serializer
         self.mml_version = mml_version
+        self.extras: dict[str, Any] = extras or {}
 
         self._packaged_symbols: dict[object, SymbolSpec] = {}
 
@@ -591,6 +594,7 @@ class Serializer:
         *,
         policy: SerializationPolicy,
         overwrite: bool = False,
+        extras: dict[str, Any] | None = None,
     ) -> str:
         """
         Serialize `obj` to disk as a ModularML artifact.
@@ -600,6 +604,7 @@ class Serializer:
             save_path (str): Output path for the resulting `.mml` file.
             policy (SerializationPolicy): Class resolution policy for `obj`.
             overwrite (bool): Overwrite existing artifacts when True.
+            extras (dict[str, Any] | None): Additional metadata forwarded via :class:`SaveContext`.
 
         Returns:
             str: Path to the written artifact file.
@@ -624,6 +629,7 @@ class Serializer:
                 artifact_path=tmp_path,
                 serializer=self,
                 mml_version=self.mml_version,
+                extras=extras,
             )
 
             # Write artifact

--- a/modularml/core/io/yaml/__init__.py
+++ b/modularml/core/io/yaml/__init__.py
@@ -55,15 +55,16 @@ def obj_to_yaml_dict(obj: Any) -> dict[str, Any]:
 
     """
     from modularml.core.experiment.experiment import Experiment
-    from modularml.core.experiment.phases.phase import ExperimentPhase
     from modularml.core.io.yaml.translators.experiment import experiment_to_yaml_dict
-    from modularml.core.io.yaml.translators.model_graph import model_graph_to_yaml_dict
+    from modularml.core.experiment.phases.phase import ExperimentPhase
     from modularml.core.io.yaml.translators.phase import phase_to_yaml_dict
-    from modularml.core.io.yaml.translators.sampler import sampler_to_yaml_dict
-    from modularml.core.io.yaml.translators.splitter import splitter_to_yaml_dict
-    from modularml.core.sampling.base_sampler import BaseSampler
-    from modularml.core.splitting.base_splitter import BaseSplitter
     from modularml.core.topology.model_graph import ModelGraph
+    from modularml.core.io.yaml.translators.model_graph import model_graph_to_yaml_dict
+    from modularml.core.sampling.base_sampler import BaseSampler
+    from modularml.core.io.yaml.translators.sampler import sampler_to_yaml_dict
+    from modularml.core.splitting.base_splitter import BaseSplitter
+    from modularml.core.io.yaml.translators.splitter import splitter_to_yaml_dict
+    
 
     if isinstance(obj, ModelGraph):
         return model_graph_to_yaml_dict(obj)
@@ -77,7 +78,6 @@ def obj_to_yaml_dict(obj: Any) -> dict[str, Any]:
         return {"splitter": d}
     if isinstance(obj, Experiment):
         return experiment_to_yaml_dict(obj)
-
     msg = f"YAML export is not supported for type: {type(obj).__name__}"
     raise TypeError(msg)
 
@@ -125,7 +125,7 @@ def yaml_dict_to_obj(
     if kind == "splitter":
         inner = d.get("splitter", d)
         return splitter_from_yaml_dict(inner)
-
+    
     msg = f"Unknown YAML kind: {kind!r}"
     raise ValueError(msg)
 

--- a/modularml/core/io/yaml/__init__.py
+++ b/modularml/core/io/yaml/__init__.py
@@ -64,7 +64,6 @@ def obj_to_yaml_dict(obj: Any) -> dict[str, Any]:
     from modularml.core.io.yaml.translators.sampler import sampler_to_yaml_dict
     from modularml.core.splitting.base_splitter import BaseSplitter
     from modularml.core.io.yaml.translators.splitter import splitter_to_yaml_dict
-    
 
     if isinstance(obj, ModelGraph):
         return model_graph_to_yaml_dict(obj)
@@ -125,7 +124,7 @@ def yaml_dict_to_obj(
     if kind == "splitter":
         inner = d.get("splitter", d)
         return splitter_from_yaml_dict(inner)
-    
+
     msg = f"Unknown YAML kind: {kind!r}"
     raise ValueError(msg)
 

--- a/modularml/core/io/yaml/translators/experiment.py
+++ b/modularml/core/io/yaml/translators/experiment.py
@@ -134,6 +134,7 @@ def experiment_from_yaml_dict(
     """
     from modularml.core.experiment.experiment import Experiment
     from modularml.core.experiment.experiment_context import ExperimentContext
+    from modularml.utils.errors.exceptions import EmptyExperimentContextError
 
     if "experiment" in d:
         d = d["experiment"]
@@ -145,7 +146,7 @@ def experiment_from_yaml_dict(
     # overwriting the active one via ExperimentContext._set_active()
     try:
         active_ctx = ExperimentContext.get_active()
-    except RuntimeError:
+    except EmptyExperimentContextError:
         active_ctx = None
     experiment = Experiment(label=label, ctx=active_ctx)
 

--- a/modularml/core/io/yaml/translators/model_graph.py
+++ b/modularml/core/io/yaml/translators/model_graph.py
@@ -168,6 +168,7 @@ def model_graph_from_yaml_dict(
     """
     from modularml.core.experiment.experiment_context import ExperimentContext
     from modularml.core.topology.model_graph import ModelGraph
+    from modularml.utils.errors.exceptions import EmptyExperimentContextError
 
     # Accept both {"model_graph": {...}} and the inner dict directly
     if "model_graph" in d:
@@ -176,7 +177,7 @@ def model_graph_from_yaml_dict(
     # Check for node label conflicts before constructing anything
     try:
         ctx = ExperimentContext.get_active()
-    except RuntimeError:
+    except EmptyExperimentContextError:
         ctx = None
 
     if ctx is not None and not overwrite:
@@ -201,7 +202,7 @@ def model_graph_from_yaml_dict(
     if d.get("optimizer"):
         graph_optimizer = _optimizer_from_dict(d["optimizer"])
 
-    built_nodes: dict[str, Any] = {}  # node_name → node instance
+    built_nodes: dict[str, Any] = {}  # node_name -> node instance
     nodes_list = []
 
     for node_cfg in nodes_cfg:

--- a/modularml/core/io/yaml/utils.py
+++ b/modularml/core/io/yaml/utils.py
@@ -82,7 +82,7 @@ def yaml_safe_cfg(value: Any) -> Any:
     if isinstance(value, dict):
         return {str(k): yaml_safe_cfg(v) for k, v in value.items()}
 
-    # Tuples → list
+    # Tuples -> list
     if isinstance(value, tuple):
         return [yaml_safe_cfg(x) for x in value]
 
@@ -96,7 +96,7 @@ def yaml_safe_cfg(value: Any) -> Any:
             return yaml_safe_cfg(value.to_dict())
         return yaml_safe_cfg(dataclasses.asdict(value))
 
-    # Classes and callables → dotted path string
+    # Classes and callables -> dotted path string
     if isinstance(value, type) or callable(value):
         return callable_to_path(value)
 

--- a/modularml/core/models/__init__.py
+++ b/modularml/core/models/__init__.py
@@ -25,9 +25,9 @@ def wrap_model(model: Any) -> BaseModel:
     wrapper class.
 
     Supported input types:
-        - PyTorch: `torch.nn.Module` → wrapped with `TorchModelWrapper`
-        - TensorFlow: `tf.keras.Model` → wrapped with `TensorflowModelWrapper`
-        - scikit-learn: `BaseEstimator` → wrapped with `ScikitModelWrapper`
+        - PyTorch: `torch.nn.Module` -> wrapped with `TorchModelWrapper`
+        - TensorFlow: `tf.keras.Model` -> wrapped with `TensorflowModelWrapper`
+        - scikit-learn: `BaseEstimator` -> wrapped with `ScikitModelWrapper`
 
     Args:
         model (Any): The model to wrap. Can be a raw model instance from a supported backend

--- a/modularml/core/references/experiment_reference.py
+++ b/modularml/core/references/experiment_reference.py
@@ -296,9 +296,6 @@ class GraphNodeReference(ExperimentNodeReference):
 
     """
 
-    node_label: str | None = None
-    node_id: str | None = None
-
     def resolve(
         self,
         ctx: ExperimentContext | None = None,
@@ -374,9 +371,8 @@ class GraphNodeReference(ExperimentNodeReference):
 
         """
         return {
+            **super().get_config(),
             "exp_node_type": "GraphNode",
-            "node_id": self.node_id,
-            "node_label": self.node_label,
         }
 
     @classmethod

--- a/modularml/core/references/experiment_reference.py
+++ b/modularml/core/references/experiment_reference.py
@@ -136,6 +136,55 @@ class ExperimentNodeReference(ExperimentReference):
     node_label: str | None = None
     node_id: str | None = None
 
+    def __post_init__(self):
+        if self.node_label is None and self.node_id is None:
+            raise ValueError("At least one of `node_label` or `node_id` must be set.")
+
+    def __hash__(self):
+        # Hash only on the primary identity field
+        return hash(self.node_id if self.node_id is not None else self.node_label)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ExperimentNodeReference):
+            return NotImplemented
+        # Two refs are equal if they share a non-None field value
+        # node_id takes priority since it's guaranteed unique
+        if self.node_id is not None and other.node_id is not None:
+            return self.node_id == other.node_id
+        if self.node_label is not None and other.node_label is not None:
+            return self.node_label == other.node_label
+        return False
+
+    def enrich(
+        self,
+        *,
+        node_id: str | None = None,
+        node_label: str | None = None,
+    ) -> None:
+        """
+        Fill in an identity field is missing after first resolution.
+
+        Only writes a field if it is currently None.
+        An existing value cannot be overwritten (once set, attributes are immutable)
+        """
+        if node_id is not None and self.node_id is None:
+            object.__setattr__(self, "node_id", node_id)
+        if node_label is not None and self.node_label is None:
+            object.__setattr__(self, "node_label", node_label)
+
+    def enrich_from_resolved(self, ctx: ExperimentContext | None = None):
+        """Fills in any missing identity field, based on the resolved value."""
+        from modularml.core.experiment.experiment_node import ExperimentNode
+
+        exp_node = self.resolve(ctx=ctx)
+        if not isinstance(exp_node, ExperimentNode):
+            msg = (
+                "Expected reference to resolve to ExperimentNode. "
+                f"Received: {type(exp_node)}."
+            )
+            raise TypeError(msg)
+        self.enrich(node_id=exp_node.node_id, node_label=exp_node.label)
+
     def resolve(
         self,
         ctx: ExperimentContext | None = None,

--- a/modularml/core/references/featureset_reference.py
+++ b/modularml/core/references/featureset_reference.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, get_args
 
 from modularml.core.data.schema_constants import (
@@ -17,7 +17,6 @@ from modularml.core.data.schema_constants import (
 from modularml.core.experiment.experiment_context import ExperimentContext
 from modularml.core.references.experiment_reference import (
     ExperimentNodeReference,
-    ExperimentReference,
     ResolutionError,
 )
 from modularml.utils.data.pyarrow_data import resolve_column_selectors
@@ -41,10 +40,6 @@ class FeatureSetReference(ExperimentNodeReference):
         tags (tuple[str, ...] | None): Tag columns or selectors.
 
     """
-
-    # ExperimentNode
-    node_label: str | None = None
-    node_id: str | None = None
 
     # FeatureSet-specific
     features: tuple[str, ...] | None = None
@@ -129,6 +124,19 @@ class FeatureSetReference(ExperimentNodeReference):
             tags=list(selected[DOMAIN_TAGS]),
         )
 
+    def enrich_from_resolved(self, ctx: ExperimentContext | None = None):
+        """Fills in any missing identity field, based on the resolved value."""
+        from modularml.core.data.featureset_view import FeatureSetView
+
+        fsv = self.resolve(ctx=ctx)
+        if not isinstance(fsv, FeatureSetView):
+            msg = (
+                "Expected reference to resolve to FeatureSetView. "
+                f"Received: {type(fsv)}."
+            )
+            raise TypeError(msg)
+        self.enrich(node_id=fsv.source.node_id, node_label=fsv.source.label)
+
     # ================================================
     # Configurable
     # ================================================
@@ -141,8 +149,7 @@ class FeatureSetReference(ExperimentNodeReference):
 
         """
         return {
-            "node_id": self.node_id,
-            "node_label": self.node_label,
+            **super().get_config(),
             "features": self.features,
             "targets": self.targets,
             "tags": self.tags,
@@ -164,7 +171,7 @@ class FeatureSetReference(ExperimentNodeReference):
 
 
 @dataclass(frozen=True)
-class FeatureSetSplitReference(ExperimentReference):
+class FeatureSetSplitReference(FeatureSetReference):
     """
     Reference to a :class:`FeatureSet` split.
 
@@ -175,12 +182,7 @@ class FeatureSetSplitReference(ExperimentReference):
 
     """
 
-    # Split-specific
-    split_name: str
-
-    # ExperimentNode
-    node_label: str | None = None
-    node_id: str | None = None
+    split_name: str = field(kw_only=True)
 
     def resolve(
         self,
@@ -243,7 +245,7 @@ class FeatureSetSplitReference(ExperimentReference):
             )
             raise ResolutionError(msg)
 
-        return node.get_split(split_name=self.split_label)
+        return node.get_split(split_name=self.split_name)
 
     # ================================================
     # Configurable
@@ -257,8 +259,7 @@ class FeatureSetSplitReference(ExperimentReference):
 
         """
         return {
-            "node_id": self.node_id,
-            "node_label": self.node_label,
+            **super().get_config(),
             "split_name": self.split_name,
         }
 
@@ -278,7 +279,7 @@ class FeatureSetSplitReference(ExperimentReference):
 
 
 @dataclass(frozen=True)
-class FeatureSetColumnReference(ExperimentReference):
+class FeatureSetColumnReference(FeatureSetReference):
     """
     Reference to a single column of a :class:`FeatureSet`.
 
@@ -291,17 +292,13 @@ class FeatureSetColumnReference(ExperimentReference):
 
     """
 
-    # FeatureSet-specific (single column)
-    domain: str
-    key: str
-    rep: str
-
-    # ExperimentNode
-    node_label: str | None = None
-    node_id: str | None = None
+    domain: str = field(kw_only=True)
+    key: str = field(kw_only=True)
+    rep: str = field(kw_only=True)
 
     def __post_init__(self):
         """Validate the configured domain."""
+        super().__post_init__()
         valid_ds = [DOMAIN_FEATURES, DOMAIN_TARGETS, DOMAIN_TAGS, DOMAIN_SAMPLE_UUIDS]
         if self.domain not in valid_ds:
             msg = f"Domain must be one of: {valid_ds}. Received: {self.domain}."
@@ -605,8 +602,7 @@ class FeatureSetColumnReference(ExperimentReference):
 
         """
         return {
-            "node_id": self.node_id,
-            "node_label": self.node_label,
+            **super().get_config(),
             "domain": self.domain,
             "key": self.key,
             "rep": self.rep,

--- a/modularml/core/sampling/similiarity_condition.py
+++ b/modularml/core/sampling/similiarity_condition.py
@@ -51,7 +51,7 @@ class SimilarityCondition(Configurable):
             If False, non-matches always score 0.0.
 
     Weight semantics:
-        - Matches always receive weight ≥ 1.0 (better matches → larger weight).
+        - Matches always receive weight ≥ 1.0 (better matches -> larger weight).
         - Non-matches receive weight < 1.0 if `allow_fallback=True`, else 0.0.
         - `fallback=False` is equivalent to \
             `weightmode='binary', min_weight=0.0, max_weight=1.0`

--- a/modularml/core/settings.py
+++ b/modularml/core/settings.py
@@ -1,0 +1,46 @@
+"""Package-wide configuration for ModularML."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass
+class ModularMLSettings:
+    """
+    Package-wide settings for ModularML.
+
+    Attributes:
+        require_unique_labels (bool):
+            When True, ExperimentContext enforces unique node labels using the
+            ERROR registration policy, regardless of per-context policy.
+            Configurable via the ``MODULARML_REQUIRE_UNIQUE_LABELS`` env var
+            or :func:`configure`.
+
+    """
+
+    require_unique_labels: bool = False
+
+
+def _init_defaults() -> ModularMLSettings:
+    val = os.getenv("MODULARML_REQUIRE_UNIQUE_LABELS", "").strip().lower()
+    return ModularMLSettings(require_unique_labels=val in ("1", "true", "yes"))
+
+
+settings: ModularMLSettings = _init_defaults()
+"""Module-level settings singleton. Mutate directly or use :func:`configure`."""
+
+
+def configure(*, require_unique_labels: bool | None = None) -> None:
+    """
+    Programmatically configure package-wide ModularML settings.
+
+    Args:
+        require_unique_labels (bool | None, optional):
+            When True, all new ExperimentContexts enforce unique node labels
+            (ERROR registration policy). Defaults to no change.
+
+    """
+    if require_unique_labels is not None:
+        settings.require_unique_labels = require_unique_labels

--- a/modularml/core/splitting/split_mixin.py
+++ b/modularml/core/splitting/split_mixin.py
@@ -401,7 +401,7 @@ class SplitMixin:
                 - Explicit fully-qualified columns (e.g. "features.voltage.raw")
                 - Domain-based selectors via `features`, `targets`, and `tags`
                 - Wildcards (e.g. "*.raw", "voltage.*", "*.*")
-                - Automatic domain prefixing ("voltage.raw" → "features.voltage.raw")
+                - Automatic domain prefixing ("voltage.raw" -> "features.voltage.raw")
                 - Optional default representation inference via `rep`
 
             No data is copied. The returned object is a lightweight view that

--- a/modularml/core/topology/graph_node.py
+++ b/modularml/core/topology/graph_node.py
@@ -145,9 +145,17 @@ class GraphNode(ABC, ExperimentNode):
             failed: list[GraphNodeReference] = []
             for r in refs:
                 try:
-                    _ = r.resolve(ctx=exp_ctx)
-                except ResolutionError:  # noqa: PERF203
+                    resolved_node = r.resolve(ctx=exp_ctx)
+                except ResolutionError:
                     failed.append(r)
+
+                # Since a reference can exist with only one of label or node_id set,
+                # ensure both are set after validating connection
+                r.enrich(
+                    node_id=getattr(resolved_node, "node_id", None),
+                    node_label=getattr(resolved_node, "label", None),
+                )
+
             if failed:
                 details = "\n".join(
                     f"  - {ref.__class__.__name__}: {ref!r}" for ref in failed

--- a/modularml/core/topology/model_graph.py
+++ b/modularml/core/topology/model_graph.py
@@ -36,6 +36,7 @@ from modularml.utils.nn.backend import (
     backend_requires_optimizer,
     is_valid_backend,
 )
+from modularml.utils.representation.summary import Summarizable
 from modularml.utils.topology.graph_search_utils import (
     get_subgraph_nodes,
     is_head_node,
@@ -60,7 +61,7 @@ torch = check_torch()
 logger = get_logger("ModelGraph")
 
 
-class ModelGraph(Configurable, Stateful):
+class ModelGraph(Configurable, Stateful, Summarizable):
     """
     Directed acyclic graph orchestrating :class:`GraphNode` nodes.
 
@@ -249,6 +250,38 @@ class ModelGraph(Configurable, Stateful):
             return False
 
         return deep_equal(self.get_state(), other.get_state())
+
+    def __repr__(self) -> str:
+        n_nodes = len(self._nodes)
+        opt = type(self._optimizer).__name__ if self._optimizer is not None else "None"
+        return (
+            f"ModelGraph(label={self.label!r}, nodes={n_nodes}, "
+            f"built={self._built}, optimizer={opt})"
+        )
+
+    def _summary_rows(self) -> list[tuple]:
+        return [
+            ("label", self.label),
+            ("is_built", str(self.is_built)),
+            (
+                "nodes",
+                [(node.label, type(node).__name__) for node in self.nodes.values()],
+            ),
+            (
+                "head_nodes",
+                [(node.label, "") for node in self.head_nodes.values()],
+            ),
+            (
+                "tail_nodes",
+                [(node.label, "") for node in self.tail_nodes.values()],
+            ),
+            (
+                "optimizer",
+                self._optimizer._summary_rows()
+                if self._optimizer is not None
+                else [("none", "")],
+            ),
+        ]
 
     @staticmethod
     def _data_format_for_node(node: GraphNode) -> DataFormat:

--- a/modularml/core/topology/model_graph.py
+++ b/modularml/core/topology/model_graph.py
@@ -28,7 +28,10 @@ from modularml.utils.data.data_format import DataFormat, get_data_format_for_bac
 from modularml.utils.data.dummy_data import make_dummy_sample_data
 from modularml.utils.environment.optional_imports import check_tensorflow, check_torch
 from modularml.utils.errors.error_handling import ErrorMode
-from modularml.utils.errors.exceptions import BackendNotSupportedError
+from modularml.utils.errors.exceptions import (
+    BackendNotSupportedError,
+    NodeNotFoundError,
+)
 from modularml.utils.logging.warnings import catch_warnings, get_logger, warn
 from modularml.utils.nn.accelerator import Accelerator
 from modularml.utils.nn.backend import (
@@ -1705,9 +1708,18 @@ class ModelGraph(Configurable, Stateful, Summarizable):
         loss_records: list[LossRecord] = []
         for loss in losses:
             weighted_raw_loss = loss.compute(ctx=ctx)
+            try:
+                _gn = self.exp_ctx.get_node(
+                    node_id=loss.node_id,
+                    enforce_type="GraphNode",
+                )
+                _node_label = _gn.label
+            except NodeNotFoundError:
+                _node_label = None
             lr = LossRecord(
                 label=loss.label,
                 node_id=loss.node_id,
+                node_label=_node_label,
                 trainable=weighted_raw_loss,
             )
             loss_records.append(lr)
@@ -1765,9 +1777,18 @@ class ModelGraph(Configurable, Stateful, Summarizable):
         loss_records: list[LossRecord] = []
         for loss in losses:
             weighted_raw_loss = loss.compute(ctx=ctx)
+            try:
+                _gn = self.exp_ctx.get_node(
+                    node_id=loss.node_id,
+                    enforce_type="GraphNode",
+                )
+                _node_label = _gn.label
+            except NodeNotFoundError:
+                _node_label = None
             lr = LossRecord(
                 label=loss.label,
                 node_id=loss.node_id,
+                node_label=_node_label,
                 trainable=weighted_raw_loss,
             )
             loss_records.append(lr)
@@ -2050,9 +2071,18 @@ class ModelGraph(Configurable, Stateful, Summarizable):
         loss_records: list[LossRecord] = []
         for loss in losses:
             weighted_raw_loss = loss.compute(ctx=ctx)
+            try:
+                _gn = self.exp_ctx.get_node(
+                    node_id=loss.node_id,
+                    enforce_type="GraphNode",
+                )
+                _node_label = _gn.label
+            except NodeNotFoundError:
+                _node_label = None
             lr = LossRecord(
                 label=loss.label,
                 node_id=loss.node_id,
+                node_label=_node_label,
                 auxiliary=weighted_raw_loss,
             )
             loss_records.append(lr)

--- a/modularml/core/training/loss.py
+++ b/modularml/core/training/loss.py
@@ -366,6 +366,7 @@ class Loss:
         if self.fn is not None:
             if self.kwargs:
                 import functools
+
                 self._callable = functools.partial(self.fn, **self.kwargs)
             else:
                 self._callable = self.fn

--- a/modularml/core/training/loss.py
+++ b/modularml/core/training/loss.py
@@ -364,7 +364,11 @@ class Loss:
 
         # Case 2: callable loss function
         if self.fn is not None:
-            self._callable = self.fn
+            if self.kwargs:
+                import functools
+                self._callable = functools.partial(self.fn, **self.kwargs)
+            else:
+                self._callable = self.fn
             return
 
         # Case 3: factory

--- a/modularml/core/training/loss_record.py
+++ b/modularml/core/training/loss_record.py
@@ -9,6 +9,10 @@ from modularml.core.experiment.experiment_context import ExperimentContext
 from modularml.core.experiment.experiment_node import ExperimentNode
 from modularml.utils.data.conversion import to_python
 from modularml.utils.data.multi_keyed_data import AxisSeries
+from modularml.utils.errors.exceptions import (
+    EmptyExperimentContextError,
+    NodeNotFoundError,
+)
 
 if TYPE_CHECKING:
     from matplotlib.pylab import Hashable
@@ -33,6 +37,7 @@ class LossRecord:
 
     label: str
     node_id: str | None = None
+    node_label: str | None = None
     trainable: Any | None = None
     auxiliary: Any | None = None
 
@@ -64,6 +69,7 @@ class LossRecord:
         return {
             "label": self.label,
             "node_id": self.node_id,
+            "node_label": self.node_label,
             "trainable": self.trainable,
             "auxiliary": self.auxiliary,
         }
@@ -83,6 +89,7 @@ class LossRecord:
         return LossRecord(
             label=self.label,
             node_id=self.node_id,
+            node_label=self.node_label,
             trainable=to_python(self.trainable),
             auxiliary=to_python(self.auxiliary),
         )
@@ -136,12 +143,31 @@ class LossRecord:
                 )
                 raise ValueError(msg)
 
+            # Enforce same node_label (allow None on either side)
+            if (
+                lr.node_label is not None
+                and ref.node_label is not None
+                and lr.node_label != ref.node_label
+            ):
+                msg = (
+                    "Cannot combine LossRecords with different node labels: "
+                    f"{ref.node_label} != {lr.node_label}."
+                )
+                raise ValueError(msg)
+
+        # Resolve shared node_label (prefer first non-None value)
+        merged_node_label = next(
+            (lr.node_label for lr in records if lr.node_label is not None),
+            None,
+        )
+
         # Combine
         t_vals = [lr.trainable for lr in records if lr.trainable is not None]
         a_vals = [lr.auxiliary for lr in records if lr.auxiliary is not None]
         return LossRecord(
             label=ref.label,
             node_id=ref.node_id,
+            node_label=merged_node_label,
             trainable=sum(t_vals) if len(t_vals) > 0 else None,
             auxiliary=sum(a_vals) if len(a_vals) > 0 else None,
         )
@@ -227,6 +253,7 @@ class LossRecord:
         return LossRecord(
             label=lr_total.label,
             node_id=lr_total.node_id,
+            node_label=lr_total.node_label,
             trainable=avg_train,
             auxiliary=avg_aux,
         )
@@ -295,13 +322,33 @@ class LossCollection(AxisSeries[LossRecord]):
 
         """
         if "node" in coords:
-            # Get actual node from given values, then retrieve node_id
             node = coords["node"]
-            if not isinstance(node, ExperimentNode):
-                exp_ctx = ExperimentContext.get_active()
-                node = exp_ctx.get_node(val=coords["node"])
-            # Replace coord value with node_id
-            coords["node"] = node.node_id
+            if isinstance(node, ExperimentNode):
+                coords["node"] = node.node_id
+                return coords
+
+            if isinstance(node, str):
+                # Fast path: active context
+                try:
+                    exp_ctx = ExperimentContext.get_active()
+                    coords["node"] = exp_ctx.get_node(val=node).node_id
+                except EmptyExperimentContextError:
+                    pass  # Offline: fall through to record scan
+                else:
+                    return coords
+
+                # Offline: scan stored records for a matching label or node_id
+                for rec in self._records:
+                    if node in (rec.node_label, rec.node_id):
+                        coords["node"] = rec.node_id
+                        return coords
+
+                known = {r.node_label or r.node_id for r in self._records}
+                msg = (
+                    f"Cannot resolve node '{node}': no active ExperimentContext "
+                    f"and no matching label or id in stored records. Known: {known}."
+                )
+                raise NodeNotFoundError(msg)
 
         return coords
 
@@ -340,7 +387,14 @@ class LossCollection(AxisSeries[LossRecord]):
                 Resolved nodes retrieved from the active experiment context.
 
         """
-        exp_ctx = ExperimentContext.get_active()
+        try:
+            exp_ctx = ExperimentContext.get_active()
+        except EmptyExperimentContextError as exc:
+            msg = (
+                "LossCollection.nodes requires an active ExperimentContext. "
+                "Use .node_ids for offline access."
+            )
+            raise EmptyExperimentContextError(msg) from exc
         return [exp_ctx.get_node(node_id=x) for x in self.node_ids]
 
     # ================================================

--- a/modularml/models/__init__.py
+++ b/modularml/models/__init__.py
@@ -6,6 +6,7 @@ from modularml.utils.nn.backend import Backend
 # Import all pre-built models
 from .torch.sequential_mlp import SequentialMLP as Torch_SequentialMLP
 from .torch.sequential_cnn import SequentialCNN as Torch_SequentialCNN
+from .torch.temporal_cnn import TemporalCNN as Torch_TemporalCNN
 
 
 # Create registry
@@ -30,6 +31,7 @@ def model_naming_fn(x: type):
 torch_models = [
     Torch_SequentialMLP,
     Torch_SequentialCNN,
+    Torch_TemporalCNN,
 ]
 for t in torch_models:
     model_registry.register(model_naming_fn(t), t)

--- a/modularml/models/torch/__init__.py
+++ b/modularml/models/torch/__init__.py
@@ -2,8 +2,10 @@
 
 from .sequential_cnn import SequentialCNN
 from .sequential_mlp import SequentialMLP
+from .temporal_cnn import TemporalCNN
 
 __all__ = [
     "SequentialCNN",
     "SequentialMLP",
+    "TemporalCNN",
 ]

--- a/modularml/models/torch/sequential_cnn.py
+++ b/modularml/models/torch/sequential_cnn.py
@@ -40,7 +40,7 @@ class SequentialCNN(TorchBaseModel):
         n_layers: int = 2,
         hidden_dim: int = 16,
         kernel_size: int = 3,
-        padding: int = 1,
+        padding: int | None = None,
         stride: int = 1,
         activation: str = "relu",
         dropout: float = 0.0,
@@ -59,7 +59,10 @@ class SequentialCNN(TorchBaseModel):
             n_layers (int): Number of convolutional blocks.
             hidden_dim (int): Number of output channels in hidden blocks.
             kernel_size (int): Kernel size for convolutions.
-            padding (int): Padding applied to convolutions.
+            padding (int | None): Padding applied to convolutions. When
+                ``None``, defaults to ``(kernel_size - 1) // 2`` (same
+                padding), which preserves the sequence length through each
+                convolution.
             stride (int): Stride per convolution.
             activation (str): Activation name resolved via
                 :func:`resolve_activation`.
@@ -219,6 +222,9 @@ class SequentialCNN(TorchBaseModel):
             self._output_shape = (1, self.hidden_dim)
 
         act_fn = resolve_activation(self.activation, backend=self.backend)
+        effective_padding = (
+            self.padding if self.padding is not None else (self.kernel_size - 1) // 2
+        )
 
         num_features, feature_len = self._input_shape
         layers = []
@@ -229,7 +235,7 @@ class SequentialCNN(TorchBaseModel):
                     out_channels=self.hidden_dim,
                     kernel_size=self.kernel_size,
                     stride=self.stride,
-                    padding=self.padding,
+                    padding=effective_padding,
                 ),
             )
             layers.append(act_fn)

--- a/modularml/models/torch/temporal_cnn.py
+++ b/modularml/models/torch/temporal_cnn.py
@@ -1,0 +1,409 @@
+"""Torch TemporalCNN reference implementation with lazy building."""
+
+import numpy as np
+
+from modularml.core.models.torch_base_model import TorchBaseModel
+from modularml.utils.data.shape_utils import ensure_tuple_shape
+from modularml.utils.data.types import TorchTensor
+from modularml.utils.environment.optional_imports import check_torch
+from modularml.utils.logging.warnings import warn
+from modularml.utils.nn.activations import resolve_activation
+from modularml.utils.nn.backend import Backend
+
+torch = check_torch()
+
+
+class ResidualBlock(torch.nn.Module):
+    """
+    One dilated residual block for use inside :class:`TemporalCNN`.
+
+    Contains two weight-normalised dilated Conv1d layers with optional
+    causal padding, configurable activation, and dropout.  A 1x1
+    identity convolution is inserted on the skip path when the channel
+    dimensions differ.
+
+    Args:
+        in_channels (int): Number of input channels.
+        out_channels (int): Number of output channels.
+        kernel_size (int): Convolution kernel size.
+        dilation (int): Dilation factor for both conv layers.
+        activation_name (str): Activation name forwarded to
+            :func:`resolve_activation`.
+        dropout (float): Dropout probability (applied after each
+            conv-activation pair via :class:`torch.nn.Dropout1d`).
+        causal (bool): When ``True``, uses left-only
+            :class:`torch.nn.ConstantPad1d` so each output time-step
+            only attends to past context.  When ``False``, symmetric
+            padding is applied via ``Conv1d(padding=...)``.
+
+    """
+
+    def __init__(
+        self,
+        *,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        dilation: int,
+        activation_name: str,
+        dropout: float = 0.0,
+        causal: bool = True,
+    ):
+        super().__init__()
+
+        pad = (kernel_size - 1) * dilation
+        sym_pad = pad // 2
+
+        # First dilated conv
+        if causal:
+            self.pad1 = torch.nn.ConstantPad1d((pad, 0), 0.0)
+            self.conv1 = torch.nn.utils.parametrizations.weight_norm(
+                torch.nn.Conv1d(
+                    in_channels,
+                    out_channels,
+                    kernel_size,
+                    dilation=dilation,
+                ),
+            )
+        else:
+            self.pad1 = torch.nn.Identity()
+            self.conv1 = torch.nn.utils.parametrizations.weight_norm(
+                torch.nn.Conv1d(
+                    in_channels,
+                    out_channels,
+                    kernel_size,
+                    padding=sym_pad,
+                    dilation=dilation,
+                ),
+            )
+        self.act1 = resolve_activation(activation_name, backend=Backend.TORCH)
+        self.dropout1 = (
+            torch.nn.Dropout1d(p=dropout) if dropout > 0 else torch.nn.Identity()
+        )
+
+        # Second dilated conv
+        if causal:
+            self.pad2 = torch.nn.ConstantPad1d((pad, 0), 0.0)
+            conv2 = torch.nn.utils.parametrizations.weight_norm(
+                torch.nn.Conv1d(
+                    out_channels,
+                    out_channels,
+                    kernel_size,
+                    dilation=dilation,
+                ),
+            )
+        else:
+            self.pad2 = torch.nn.Identity()
+            conv2 = torch.nn.utils.parametrizations.weight_norm(
+                torch.nn.Conv1d(
+                    out_channels,
+                    out_channels,
+                    kernel_size,
+                    padding=sym_pad,
+                    dilation=dilation,
+                ),
+            )
+
+        self.conv2 = conv2
+        self.act2 = resolve_activation(activation_name, backend=Backend.TORCH)
+        self.dropout2 = (
+            torch.nn.Dropout1d(p=dropout) if dropout > 0 else torch.nn.Identity()
+        )
+
+        # Residual activation (applied after skip addition)
+        self.act_residual = resolve_activation(activation_name, backend=Backend.TORCH)
+
+        # 1x1 conv on the skip path when channel dims differ
+        self.identity_conv = (
+            torch.nn.Conv1d(in_channels, out_channels, 1)
+            if in_channels != out_channels
+            else None
+        )
+
+    def forward(self, x: TorchTensor) -> TorchTensor:
+        """
+        Forward pass through the residual block.
+
+        Args:
+            x (TorchTensor): Input of shape ``(batch, in_channels, length)``.
+
+        Returns:
+            TorchTensor: Output of shape ``(batch, out_channels, length)``.
+
+        """
+        out = self.pad1(x)
+        out = self.act1(self.conv1(out))
+        out = self.dropout1(out)
+
+        out = self.pad2(out)
+        out = self.act2(self.conv2(out))
+        out = self.dropout2(out)
+
+        residual = x if self.identity_conv is None else self.identity_conv(x)
+        return self.act_residual(out + residual)
+
+
+class TemporalCNN(TorchBaseModel):
+    """
+    Temporal Convolutional Network.
+
+    Each block contains two dilated Conv1d layers with weight
+    normalization, configurable activation, and optional dropout.
+    Dilation doubles per block, giving an exponentially growing
+    receptive field.
+
+    Attributes:
+        n_blocks (int): Number of :class:`ResidualBlock` layers.
+        hidden_dim (int): Channel width used throughout the network.
+        kernel_size (int): Convolution kernel size.
+        activation (str): Activation name resolved via
+            :func:`resolve_activation`.
+        dropout (float): Dropout probability applied after each
+            conv-activation pair.
+        causal (bool): Whether left-only causal padding is used.
+        flatten_output (bool): Whether to append a linear projection
+            to match the target output shape.
+        tcn (torch.nn.Sequential | None): Stacked residual blocks.
+        fc (torch.nn.Linear | None): Optional linear output projection.
+
+    """
+
+    def __init__(
+        self,
+        *,
+        input_shape: tuple[int, ...] | None = None,
+        output_shape: tuple[int, ...] | None = None,
+        n_blocks: int = 4,
+        hidden_dim: int = 64,
+        kernel_size: int = 3,
+        activation: str = "relu",
+        dropout: float = 0.0,
+        causal: bool = True,
+        flatten_output: bool = True,
+        **kwargs,
+    ):
+        """
+        Initialize the temporal CNN with optional lazy building.
+
+        Args:
+            input_shape (tuple[int, ...] | None): Shape excluding the
+                batch dimension.
+            output_shape (tuple[int, ...] | None): Desired output shape
+                excluding the batch dimension.
+            n_blocks (int): Number of residual blocks.  Dilation doubles
+                per block (1, 2, 4, ...).
+            hidden_dim (int): Number of channels in every residual block.
+            kernel_size (int): Kernel size for all convolutions.
+            activation (str): Activation name resolved via
+                :func:`resolve_activation`.
+            dropout (float): Dropout probability applied after each
+                conv-activation pair inside each block.
+            causal (bool): Use left-only causal padding when ``True``,
+                symmetric padding when ``False``.
+            flatten_output (bool): Append a linear projection to match
+                ``output_shape`` when ``True``.
+            **kwargs (Any): Extra keyword arguments forwarded to
+                :class:`TorchBaseModel`.
+
+        """
+        # Pass all init args to parent for automatic get_config/from_config
+        super().__init__(
+            input_shape=input_shape,
+            output_shape=output_shape,
+            n_blocks=n_blocks,
+            hidden_dim=hidden_dim,
+            kernel_size=kernel_size,
+            activation=activation,
+            dropout=dropout,
+            causal=causal,
+            flatten_output=flatten_output,
+            **kwargs,
+        )
+
+        # Ensure shape formatting (if given)
+        self._input_shape: tuple[int, ...] | None = ensure_tuple_shape(
+            shape=input_shape,
+            min_len=2,
+            max_len=3,
+            allow_null_shape=True,
+        )
+        self._output_shape: tuple[int, ...] | None = ensure_tuple_shape(
+            shape=output_shape,
+            min_len=2,
+            max_len=3,
+            allow_null_shape=True,
+        )
+
+        # Init args
+        self.n_blocks = n_blocks
+        self.hidden_dim = hidden_dim
+        self.kernel_size = kernel_size
+        self.activation = activation
+        self.dropout = dropout
+        self.causal = causal
+        self.flatten_output = flatten_output
+
+        # Layers (constructed in build())
+        self.tcn = None
+        self.fc = None
+
+        # Build immediately if both shapes are known
+        if self._input_shape and self._output_shape:
+            self.build(self._input_shape, self._output_shape)
+
+    @property
+    def input_shape(self) -> tuple[int, ...] | None:
+        """
+        Return the expected input shape excluding the batch dimension.
+
+        Returns:
+            tuple[int, ...] | None: Input shape when known.
+
+        """
+        return self._input_shape
+
+    @property
+    def output_shape(self) -> tuple[int, ...] | None:
+        """
+        Return the output shape excluding the batch dimension.
+
+        Returns:
+            tuple[int, ...] | None: Output shape when known.
+
+        """
+        return self._output_shape
+
+    def build(
+        self,
+        input_shape: tuple[int, ...] | None = None,
+        output_shape: tuple[int, ...] | None = None,
+        *,
+        force: bool = False,
+    ):
+        """
+        Build residual blocks and the optional linear projection.
+
+        Args:
+            input_shape (tuple[int, ...] | None):
+                Shape excluding the batch dimension.
+            output_shape (tuple[int, ...] | None):
+                Target shape excluding the batch dimension.
+            force (bool):
+                Whether to rebuild existing layers.
+
+        Raises:
+            ValueError: If shapes conflict with previously supplied ones
+                without forcing, or when ``input_shape`` is missing.
+            UserWarning: If ``output_shape`` is missing and defaults are
+                inferred.
+
+        """
+        # Validate / store input_shape
+        if input_shape:
+            input_shape = ensure_tuple_shape(
+                shape=input_shape,
+                min_len=2,
+                max_len=None,
+                allow_null_shape=False,
+            )
+            if (
+                (self._input_shape is not None)
+                and (input_shape != self._input_shape)
+                and (not force)
+            ):
+                msg = (
+                    f"Build called with `input_shape={input_shape}` but input shape is already defined "
+                    f"with value `{self._input_shape}`. To override the existing shape, set `force=True`."
+                )
+                raise ValueError(msg)
+            self._input_shape = input_shape
+
+        # Validate / store output_shape
+        if output_shape:
+            output_shape = ensure_tuple_shape(
+                shape=output_shape,
+                min_len=2,
+                max_len=None,
+                allow_null_shape=False,
+            )
+            if (
+                (self._output_shape is not None)
+                and (output_shape != self._output_shape)
+                and (not force)
+            ):
+                msg = (
+                    f"Build called with `output_shape={output_shape}` but output shape is already defined "
+                    f"with value `{self._output_shape}`. To override the existing shape, set `force=True`."
+                )
+                raise ValueError(msg)
+            self._output_shape = output_shape
+
+        if self.is_built and not force:
+            return
+
+        if self._input_shape is None:
+            raise ValueError("Input shape must be provided before building the model.")
+        if self._output_shape is None:
+            msg = "No output shape provided. Using default shape of (1, hidden_dim)."
+            warn(msg, category=UserWarning, stacklevel=2)
+            self._output_shape = (1, self.hidden_dim)
+
+        # Stack n_blocks residual blocks; dilation doubles per block
+        in_channels = self._input_shape[0]
+        blocks = []
+        for i in range(self.n_blocks):
+            dilation = 2**i
+            block_in = in_channels if i == 0 else self.hidden_dim
+            blocks.append(
+                ResidualBlock(
+                    in_channels=block_in,
+                    out_channels=self.hidden_dim,
+                    kernel_size=self.kernel_size,
+                    dilation=dilation,
+                    activation_name=self.activation,
+                    dropout=self.dropout,
+                    causal=self.causal,
+                ),
+            )
+
+        self.tcn = torch.nn.Sequential(*blocks)
+
+        if self.flatten_output:
+            dummy = torch.zeros(1, *self._input_shape)
+            with torch.no_grad():
+                tcn_out = self.tcn(dummy)
+            conv_out_dim = tcn_out.shape[1] * tcn_out.shape[2]
+
+            flat_output_dim = int(np.prod(self._output_shape))
+            self.fc = torch.nn.Linear(conv_out_dim, flat_output_dim)
+
+        self._built = True
+
+    def forward(self, x: TorchTensor) -> TorchTensor:
+        """
+        Run the forward pass through the temporal CNN.
+
+        Args:
+            x (TorchTensor):
+                Input tensor of shape ``(batch, channels, length)``.
+                A 2-D input ``(batch, length)`` has a channel dimension
+                inserted automatically.
+
+        Returns:
+            TorchTensor: Output tensor shaped ``(batch, *output_shape)``.
+
+        """
+        if x.ndim == 2:
+            x = x.unsqueeze(1)  # (batch, 1, length)
+
+        if not self.is_built:
+            self.build(input_shape=tuple(x.shape[1:]))
+
+        x = self.tcn(x)
+
+        if self.flatten_output:
+            x = x.view(x.size(0), -1)
+            x = self.fc(x)
+            x = x.view(x.size(0), *self._output_shape)
+
+        return x

--- a/modularml/utils/data/conversion.py
+++ b/modularml/utils/data/conversion.py
@@ -740,6 +740,14 @@ def to_numpy(
     if isinstance(obj, np.ndarray):
         return obj
 
+    # tensors
+    torch = check_torch()
+    if torch is not None and isinstance(obj, torch.Tensor):
+        return obj.detach().cpu().numpy()
+    tf = check_tensorflow()
+    if tf is not None and isinstance(obj, tf.Tensor):
+        return obj.numpy()
+
     py_obj = to_python(obj)
 
     # Dicts must use DICT_NUMPY format unless coerced

--- a/modularml/utils/data/conversion.py
+++ b/modularml/utils/data/conversion.py
@@ -317,12 +317,12 @@ def merge_dict_of_arrays_to_numpy(
 
     The behavior depends on the specified `mode`:
         - **"stack"**:   Adds a new axis for the dictionary keys (default axis=0).
-                         e.g. [(10, 4), (10, 4)] → (2, 10, 4)
+                         e.g. [(10, 4), (10, 4)] -> (2, 10, 4)
         - **"concat"**:  Concatenates along an existing axis (default axis=0).
-                         e.g. [(10, 4), (10, 4)] → (20, 4)
+                         e.g. [(10, 4), (10, 4)] -> (20, 4)
         - **"flatten"**: Flattens and concatenates across features.
-                         e.g. [(10, 4), (10, 3)] → (10, 7)
-        - **"auto"**:    Attempts stack → concat(axis=0) → concat(axis=-1) → flatten.
+                         e.g. [(10, 4), (10, 3)] -> (10, 7)
+        - **"auto"**:    Attempts stack -> concat(axis=0) -> concat(axis=-1) -> flatten.
 
     Args:
         data (dict[str, np.ndarray]): Mapping of key to array-like objects to merge.

--- a/modularml/utils/data/formatting.py
+++ b/modularml/utils/data/formatting.py
@@ -69,7 +69,7 @@ def format_value_to_sig_digits(
 
 
 def flatten_dict_paths(
-    d: dict[str, any],
+    d: dict[str, Any],
     prefix: str = "",
     separator: str = ".",
 ) -> list[str]:

--- a/modularml/utils/data/formatting.py
+++ b/modularml/utils/data/formatting.py
@@ -60,7 +60,7 @@ def format_value_to_sig_digits(
         # Scale number so we can round to sig_digits
         factor = 10 ** (order - sig_digits + 1)
         rounded = normal_round(value / factor) * factor
-        # Decide decimals: if order >= sig_digits-1 → no decimals, else show needed
+        # Decide decimals: if order >= sig_digits-1 -> no decimals, else show needed
         decimals = max(0, sig_digits - order - 1)
         return f"{rounded:.{decimals}f}"
 

--- a/modularml/utils/data/shape_utils.py
+++ b/modularml/utils/data/shape_utils.py
@@ -22,10 +22,10 @@ def shapes_similar_except_singleton(
     Returns True if two shapes are equal except for singleton (size-1) dimensions.
 
     Examples:
-        (32, 1, 4) ≈ (32, 4)        → True
-        (1, 64, 1, 1) ≈ (64,)       → True
-        (16, 8, 4) ≈ (8, 16, 4)     → False  (order mismatch)
-        (32, 2, 4) ≈ (32, 4)        → False  (non-singleton mismatch)
+        (32, 1, 4) ≈ (32, 4)        -> True
+        (1, 64, 1, 1) ≈ (64,)       -> True
+        (16, 8, 4) ≈ (8, 16, 4)     -> False  (order mismatch)
+        (32, 2, 4) ≈ (32, 4)        -> False  (non-singleton mismatch)
 
     Args:
         shape_a (tuple[int, ...]): First shape.

--- a/modularml/utils/errors/exceptions.py
+++ b/modularml/utils/errors/exceptions.py
@@ -220,3 +220,26 @@ class ShapeSpecError(ModularMLError):
         if message is None:
             message = "Invalid ShapeSpec."
         super().__init__(message)
+
+
+class ExperimentContextError(ModularMLError):
+    """Base exception for ExperimentContext-related issues."""
+
+
+class EmptyExperimentContextError(ExperimentContextError):
+    """Raised when there is no active ExperimentContext."""
+
+    def __init__(self, message: str | None = None):
+        super().__init__(message or "There is no active ExperimentContext.")
+
+
+class NodeNotFoundError(ExperimentContextError, KeyError):
+    """
+    Raised when a node cannot be found in the active ExperimentContext.
+
+    Inherits from KeyError for backward compatibility with existing
+    ``except KeyError`` handlers around ``get_node()`` calls.
+    """
+
+    def __init__(self, message: str | None = None):
+        ModularMLError.__init__(self, message or "Node not found in ExperimentContext.")

--- a/modularml/utils/nn/accelerator.py
+++ b/modularml/utils/nn/accelerator.py
@@ -285,6 +285,36 @@ class Accelerator:
         """
         return cls(device=f"gpu:{index}", pin_memory=pin_memory)
 
+    @classmethod
+    def all_available(cls) -> list[str]:
+        """
+        Return a list of all available device strings on this machine.
+
+        Tries PyTorch first; if not installed, falls back to TensorFlow.
+        CPU is always included. CUDA/GPU devices are listed as ``"gpu:N"``
+        (backend-agnostic form). MPS is included when available (PyTorch only).
+
+        Returns:
+            list[str]: Available device strings, e.g.
+                ``["cpu", "gpu:0", "gpu:1", "mps"]``.
+
+        """
+        devices: list[str] = ["cpu"]
+        torch = check_torch()
+        if torch is not None:
+            if torch.cuda.is_available():
+                for i in range(torch.cuda.device_count()):
+                    devices.append(f"gpu:{i}")
+            if torch.backends.mps.is_available():
+                devices.append("mps")
+            return devices
+        tf = check_tensorflow()
+        if tf is not None:
+            gpus = tf.config.list_physical_devices("GPU")
+            for i in range(len(gpus)):
+                devices.append(f"gpu:{i}")
+        return devices
+
     # ================================================
     # Dunders
     # ================================================

--- a/modularml/utils/representation/summary.py
+++ b/modularml/utils/representation/summary.py
@@ -21,9 +21,9 @@ def _try_inline(key: str, rows: Iterable[SummaryRow]) -> str | None:
     Try to render iterable inline.
 
     Rules:
-        - `(k, "")`  → render as `k`
-        - `(k, v)`   → render as `k=v`
-        - Nested iterables → not inlineable
+        - `(k, "")`  -> render as `k`
+        - `(k, v)`   -> render as `k=v`
+        - Nested iterables -> not inlineable
 
     Args:
         key (str): Parent label.


### PR DESCRIPTION
## Description
Collections of small fixes and feature improvements.
1. Added support of Experiment file serialization that omits the raw FeatureSet data. Previously, add data contained in FeatureSet was forced into the final Experiment.mml file. This is prohibitive for large datasets. Now, experiments can be saved without FeatureSets, where FeatureSets are re-merged on Experiment.load(). The Experiment file still records all metadata of the prior FeatureSet and validates the re-attached FeatureSets.
2. Fixed issue where serialized result containers (eg CVResults) stored only the node ID of the node that produces some given results. This makes it very hard to determine which results belong to which node when there is no active ExperimentContext. The mapping of node ID to node label is now preserved in result containers. Users can now query results by node ID or node label, even when there is no active experiment context.
3. Minor docstring and convenience method updates:
    - Accelerator class has new method to list all available hardware for the active device
    - __repr__ method added to ModelGraph
    - SequentialCNN default padding size is now relative to kernel size
4. New TemporalCNN class added (only implemented in PyTorch). Uses residual dilated causal convolutions. Based on: https://github.com/locuslab/TCN

## Related Issues
N/A

## How Has This Been Tested?
- [X] Local pytest run
- [X] CI passes
- [ ] Manual checks (describe if needed)

## Checklist
- [x] My code follows project style guidelines: `nox -s pre-commit`
- [x] I have added tests that prove my fix is effective or my feature works: `nox -s unit`
- [x] I have updated documentation if needed: `nox -s docs`
- [ ] I have linked related issues
